### PR TITLE
:bug: Fix warnings about direct usage of `result_backend` and `task_id_generator`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,11 +43,3 @@ jobs:
           make install py_version="${{ matrix.py_version }}"
       - name: Run pytest check for Python ${{ matrix.py_version }}
         run: make test py_version=${{ matrix.py_version }}
-      - name: Show Coverage
-        if: github.event_name == 'pull_request' && matrix.py_version == '3.12'
-        uses: orgoro/coverage@v3.2
-        with:
-            coverageFile: coverage.xml
-            thresholdAll: 0.90
-            thresholdNew: 0.95
-            token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "0 0 * * 0" # Runs every Sunday at midnight UTC
 
+permissions:
+  pull-requests: write
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -28,10 +31,6 @@ jobs:
       matrix:
         py_version: ["3.10", "3.11", "3.12"]
     runs-on: "ubuntu-latest"
-    permissions:
-      id-token: write
-      contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: "Set up Python"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      issues: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      issues: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -34,9 +34,8 @@ s3_result_backend = S3Backend(
 
 broker = SQSBroker(
     endpoint_url="http://localhost:4566",
-    result_backend=s3_result_backend,
     sqs_queue_name="my-queue",
-)
+).with_result_backend(s3_result_backend)
 
 
 @broker.task

--- a/taskiq_aio_sqs/sqs_broker.py
+++ b/taskiq_aio_sqs/sqs_broker.py
@@ -52,8 +52,6 @@ class SQSBroker(AsyncBroker):
         max_number_of_messages: int = 1,
         delay_seconds: int = 0,
         s3_extended_bucket_name: str | None = None,
-        result_backend: AsyncResultBackend | None = None,
-        task_id_generator: Callable[[], str] | None = None,
     ) -> None:
         """Initialize the SQS broker.
 
@@ -69,12 +67,10 @@ class SQSBroker(AsyncBroker):
         :param delay_seconds: The delay for message delivery (0-900), this will
         configure a default.
         :param s3_extended_bucket_name: The S3 bucket name for extended storage.
-        :param result_backend: The result backend for task results.
-        :param task_id_generator: A callable to generate task IDs.
 
         :raises BrokerInputConfigError: If the configuration is invalid.
         """
-        super().__init__(result_backend, task_id_generator)
+        super().__init__()
 
         self._aws_region = region_name
         self._aws_access_key_id = aws_access_key_id

--- a/taskiq_aio_sqs/sqs_broker.py
+++ b/taskiq_aio_sqs/sqs_broker.py
@@ -17,7 +17,6 @@ from annotated_types import Ge, Le
 from botocore.exceptions import ClientError
 from pydantic import TypeAdapter
 from taskiq import AsyncBroker
-from taskiq.abc.result_backend import AsyncResultBackend
 from taskiq.acks import AckableMessage
 from taskiq.message import BrokerMessage
 from types_aiobotocore_s3.client import S3Client


### PR DESCRIPTION
## Description

- Deleted direct pass of `result_backend` and `task_id_generator` to `SQSBroker` constructor.
- Changed example of usage in README.md

## Context and Motivation

Closes #14 