### PR TITLE
👷 Use dev group instead of legacy dev-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ dependencies = [
     "taskiq[orjson]>=0.11.12,<1"
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff==0.11.7",
     "pyright==1.1.380",
     "pre-commit==3.8.0",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Use dev group instead of legacy dev-dependencies

## Context and Motivation
<!--- Describe your reasoning for this change in detail --> 
I misread uv docs, they're so fast to deprecate things...