### PR TITLE
:sparkles: Implement Multi Queue Support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,6 @@ jobs:
         uses: LocalStack/setup-localstack@v0.2.2
         with:
           image-tag: '3.4.0'
-          configuration: SQS_ENABLE_MESSAGE_RETENTION_PERIOD=1
+          configuration: SQS_ENABLE_MESSAGE_RETENTION_PERIOD=1 LOCALSTACK_ACKNOWLEDGE_ACCOUNT_REQUIREMENT=1
       - name: Run pytest check for Python ${{ matrix.py_version }}
         run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,6 @@ jobs:
       matrix:
         py_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: "ubuntu-latest"
-    env:
-      LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - id: setup-uv
@@ -41,10 +39,7 @@ jobs:
         with:
           enable-cache: true
           python-version: ${{ matrix.py_version }}
-      - name: Start LocalStack
-        uses: LocalStack/setup-localstack@v0.2.2
-        with:
-          image-tag: '3.4.0'
-          configuration: SQS_ENABLE_MESSAGE_RETENTION_PERIOD=1 LOCALSTACK_ACKNOWLEDGE_ACCOUNT_REQUIREMENT=1
+      - name: Start MiniStack
+        uses: docker://ministackorg/ministack:latest
       - name: Run pytest check for Python ${{ matrix.py_version }}
         run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,5 @@ jobs:
         with:
           enable-cache: true
           python-version: ${{ matrix.py_version }}
-      - name: Start MiniStack
-        uses: docker://ministackorg/ministack:latest
       - name: Run pytest check for Python ${{ matrix.py_version }}
-        run: make test
+        run: make test-ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
       matrix:
         py_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: "ubuntu-latest"
+    env:
+      LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - id: setup-uv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,5 +39,10 @@ jobs:
         with:
           enable-cache: true
           python-version: ${{ matrix.py_version }}
+      - name: Start LocalStack
+        uses: LocalStack/setup-localstack@v0.2.2
+        with:
+          image-tag: '3.4.0'
+          configuration: SQS_ENABLE_MESSAGE_RETENTION_PERIOD=1
       - name: Run pytest check for Python ${{ matrix.py_version }}
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -32,13 +32,19 @@ test-ci: ministack-init run-tests ministack-stop ## Run testing and coverage.
 
 .PHONY: ministack-init
 ministack-init: ## Starts ministack AWS emulator
-	uv run ministack &
-	sleep 2
-	curl -f http://localhost:4566/_ministack/health > /dev/null || (echo "MiniStack failed to start"; exit 1)
+	uv run ministack -d
+	@for attempt in 1 2 3 4 5 6 7 8 9 10; do \
+		if curl -fsS http://localhost:4566/_ministack/health > /dev/null; then \
+			exit 0; \
+		fi; \
+		sleep 1; \
+	done; \
+	echo "MiniStack failed to start"; \
+	exit 1
 
 .PHONY: ministack-stop
 ministack-stop: ## Stops ministack AWS emulator
-	uv run ministack stop
+	uv run ministack --stop
 
 # Backwards compatibility aliases
 .PHONY: localstack-init

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test-only: localstack-init
 test: localstack-init run-tests localstack-stop badge ## Run testing and coverage.
 
 .PHONY: test-ci
-test-ci: localstack-init run-tests localstack-stop ## Run testing and coverage.
+test-ci: run-tests ## Run testing and coverage.
 
 .PHONY: localstack-init
 localstack-init: ## Starts localstack with init script

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test-only: ministack-init
 test: ministack-init run-tests ministack-stop badge ## Run testing and coverage.
 
 .PHONY: test-ci
-test-ci: run-tests ## Run testing and coverage.
+test-ci: ministack-init run-tests ministack-stop ## Run testing and coverage.
 
 .PHONY: ministack-init
 ministack-init: ## Starts ministack AWS emulator

--- a/Makefile
+++ b/Makefile
@@ -20,23 +20,32 @@ run-tests:
 	uv run pytest -x --cov=taskiq_aio_sqs --cov-report term-missing --cov-fail-under=95 --cov-report xml:coverage.xml
 
 .PHONY: test-only ## Run only some tests (usage: make test-only filter=test_name)
-test-only: localstack-init
+test-only: ministack-init
 	uv run pytest -vk "$(filter)" || true
-	$(MAKE) localstack-stop
+	$(MAKE) ministack-stop
 
 .PHONY: test ## Run testing and coverage.
-test: localstack-init run-tests localstack-stop badge ## Run testing and coverage.
+test: ministack-init run-tests ministack-stop badge ## Run testing and coverage.
 
 .PHONY: test-ci
 test-ci: run-tests ## Run testing and coverage.
 
+.PHONY: ministack-init
+ministack-init: ## Starts ministack AWS emulator
+	uv run ministack &
+	sleep 2
+	curl -f http://localhost:4566/_ministack/health > /dev/null || (echo "MiniStack failed to start"; exit 1)
+
+.PHONY: ministack-stop
+ministack-stop: ## Stops ministack AWS emulator
+	uv run ministack stop
+
+# Backwards compatibility aliases
 .PHONY: localstack-init
-localstack-init: ## Starts localstack with init script
-	SQS_ENABLE_MESSAGE_RETENTION_PERIOD=1 uv run localstack start -d --no-banner; uv run  localstack wait -t 45
+localstack-init: ministack-init
 
 .PHONY: localstack-stop
-localstack-stop: ## Starts localstack with init script
-	uv run localstack stop
+localstack-stop: ministack-stop
 
 ##@ 👷 Quality
 .PHONY: ruff-check

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Inspired by the [taskiq-sqs](https://github.com/ApeWorX/taskiq-sqs) broker.
 pip install taskiq-aio-sqs
 ```
 
+Requirements:
+- Pydantic v2 (`pydantic>=2.0,<3.0`)
+
 ## General Usage:
 Here is an example of how to use the SQS broker with the S3 backend:
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Inspired by the [taskiq-sqs](https://github.com/ApeWorX/taskiq-sqs) broker.
 ## Key Features
 
 - **Async SQS Broker**: Fully asynchronous SQS message broker with support for standard and FIFO queues ([see General Usage](#general-usage))
+- **Multi-Queue Routing**: Register multiple queues and route tasks per message/task label ([see Multi-Queue Usage](#multi-queue-usage))
 - **S3 Result Backend**: Store task results in S3, ideal for large result payloads ([see General Usage](#general-usage))
 - **Extended Messages**: Automatic S3 storage for messages exceeding SQS limits ([see Extended Messages with S3](#extended-messages-with-s3))
 - **Message Batching**: Improved performance + cost reduction through batching multiple messages in single SQS operations ([see Message Batching](#message-batching))
@@ -45,7 +46,7 @@ broker = SQSBroker(
 ).with_result_backend(s3_result_backend)
 
 
-@broker.task
+@broker.task()
 async def i_love_aws() -> None:
     """I hope my cloud bill doesn't get too high!"""
     await asyncio.sleep(5.5)
@@ -53,14 +54,70 @@ async def i_love_aws() -> None:
 
 
 async def main():
+    await broker.startup()
     task = await i_love_aws.kiq()
     print(await task.wait_result())
+    await broker.shutdown()
 
 
 if __name__ == "__main__":
     asyncio.run(main())
 
 ```
+
+### Multi-Queue Usage:
+
+Use `SQSQueue` definitions with `with_queues` / `with_default_queue` before startup, then
+route tasks using the `queue` label.
+
+```python
+from taskiq_aio_sqs import SQSBroker, SQSQueue
+
+broker = SQSBroker(
+    sqs_queue_name="taskiq-default",
+)
+
+critical_queue = SQSQueue(name="taskiq-critical")
+fifo_queue = SQSQueue(name="taskiq-events.fifo", is_fifo=True)
+
+broker.with_queues(critical_queue, fifo_queue)
+
+
+@broker.task(queue="taskiq-critical")
+async def critical_task() -> None:
+    pass
+
+
+@broker.task()
+async def normal_task() -> None:
+    pass
+
+
+async def publish_examples() -> None:
+    await broker.startup()
+
+    # Uses default queue (taskiq-default)
+    await normal_task.kiq()
+
+    # Uses queue from task decorator
+    await critical_task.kiq()
+
+    # Per-call queue override
+    await normal_task.kicker().with_labels(queue="taskiq-critical").kiq()
+
+    # FIFO queue with explicit group
+    await normal_task.kicker().with_labels(
+        queue="taskiq-events.fifo",
+        group_id="orders",
+    ).kiq()
+
+    await broker.shutdown()
+```
+
+Notes:
+- Queue names must be registered with `with_queues` (or be the default queue) before `startup()`.
+- `listen()` consumes from all configured queues.
+
 ### Delayed Tasks:
 
 Delayed tasks can be created in 3 ways:
@@ -94,7 +151,7 @@ async def main():
     await delayed_task.kiq()
 
     # This message is going to be received after the delay in 4 seconds.
-    # Since we overriden the `delay` label using kicker.
+    # Since we override the `delay` label using kicker.
     await delayed_task.kicker().with_labels(delay=4).kiq()
 
 ```
@@ -157,7 +214,8 @@ async def main():
 **Important Notes:**
 - Batching works with both standard and FIFO queues
 - Messages in the same batch will have the same MessageGroupId when using FIFO queues
-- Batching is automatically disabled for tasks with custom delays + s3 extension
+- Messages with per-message `delay` labels are sent immediately (not batched)
+- Messages using S3 extended payload flow are sent immediately (not batched)
 - The broker ensures all messages are sent when shutting down, even partial batches
 
 ### Extended Messages with S3:
@@ -223,11 +281,11 @@ async def main():
     # These tasks will be processed in order for each user,
     # but different users can be processed in parallel
     await process_user_action.kicker().with_labels(
-        group_id=f"user_{user_id}"
+        group_id="user_123"
     ).kiq(user_id=123, action="login")
 
     await process_user_action.kicker().with_labels(
-        group_id=f"user_{user_id}"
+        group_id="user_123"
     ).kiq(user_id=123, action="update_profile")
 
     await process_user_action.kicker().with_labels(
@@ -254,8 +312,9 @@ SQS Broker parameters:
 * `aws_access_key_id` - aws access key id (Optional).
 * `aws_secret_access_key` - aws secret access key (Optional).
 * `use_task_id_for_deduplication` - use task_id for deduplication, this is useful when using a Fifo queue without content based deduplication, defaults to False.
-* `wait_time_seconds` - wait time in seconds for long polling, defaults to 0.
+* `wait_time_seconds` - wait time in seconds for long polling, defaults to 10.
 * `max_number_of_messages` - maximum number of messages to receive, defaults to 1 (max 10).
+* `visibility_timeout` - optional visibility timeout for received messages.
 * `delay_seconds` - default delay for message delivery (0-900), defaults to 0.
 * `enable_batching` - enable message batching for improved performance, defaults to False.
 * `batch_size` - maximum number of messages to batch together (1-10), defaults to 10.
@@ -267,6 +326,14 @@ SQS Broker parameters:
 * `task_id_generator` - custom task_id generator (Optional).
 * `result_backend` - custom result backend (Optional).
 * `is_fair_queue` - : Whether the queue is a fair queue, if True, it will use the `task_name` as the MessageGroupId for all messages.
+
+`SQSQueue` parameters (for multi-queue configuration):
+* `name` - queue name.
+* `is_fifo` - whether queue is FIFO.
+* `max_number_of_messages` - per-queue receive batch size (1-10).
+* `wait_time_seconds` - per-queue long poll wait (0-20).
+* `visibility_timeout` - per-queue visibility timeout.
+* `options` - reserved mapping for queue-level options.
 
 **Task Labels:**
 * `delay` - override the default delay for a specific task (0-900 seconds). Not supported for FIFO queues.
@@ -294,7 +361,8 @@ To setup the project, you can run the following commands:
 ```bash
 make install
 ```
-This will install the required dependencies for the project just using pip.
+This installs the required dependencies for local development.
+The Makefile uses `uv` under the hood.
 
 ## Linting
 We use pre-commit to do linting locally, this will be included in the dev dependencies.

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ async def main():
 ## Configuration:
 
 SQS Broker parameters:
-* `endpoint_url` - url to access sqs, this is not required, but is useful when running on localstack.
+* `endpoint_url` - url to access sqs, this is not required, but is useful when running on local AWS emulators like MiniStack or LocalStack.
 * `sqs_queue_name` - name of the sqs queue.
 * `region_name` - region name, defaults to `us-east-1`.
 * `aws_access_key_id` - aws access key id (Optional).
@@ -344,7 +344,7 @@ SQS Broker parameters:
 S3 Result Backend parameters:
 * `bucket_name` - name of the s3 bucket.
 * `base_path` - base path for the s3 objects, defaults to "".
-* `endpoint_url` - url to access s3, this is not required, but is useful when running on localstack.
+* `endpoint_url` - url to access s3, this is not required, but is useful when running on local AWS emulators like MiniStack or LocalStack.
 * `region_name` - region name, defaults to `us-east-1`.
 * `aws_access_key_id` - aws access key id (Optional).
 * `aws_secret_access_key` - aws secret access key (Optional).
@@ -381,5 +381,10 @@ To run tests, you can use the following command:
 ```bash
 make test
 ```
-In the background this will setup localstack to replicate the AWS services, and run the tests.
+In the background this will setup MiniStack (free open-source AWS emulator) to replicate the AWS services, and run the tests.
 It will also generate the coverage report and the badge.
+
+You can also use Docker Compose to run MiniStack separately:
+```bash
+docker-compose up -d
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.8'
+
+services:
+  ministack:
+    image: ministackorg/ministack:latest
+    container_name: taskiq_aio_sqs_ministack
+    ports:
+      - "4566:4566"
+    environment:
+      # AWS Service Configuration
+      AWS_DEFAULT_REGION: us-east-1
+      # MiniStack Configuration
+      GATEWAY_PORT: 4566
+      MINISTACK_ACCOUNT_ID: "000000000000"
+      MINISTACK_REGION: us-east-1
+      LOG_LEVEL: INFO
+      # Persist state between restarts (optional)
+      PERSIST_STATE: "0"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4566/_ministack/health"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+      start_period: 5s
+    volumes:
+      # Optional: Mount init scripts for auto-setup (boot.d, ready.d)
+      # - ./init-scripts:/docker-entrypoint-initaws.d
+
+      # Optional: Persist MiniStack state across restarts
+      # - ministack-data:/tmp/ministack-state
+    networks:
+      - taskiq-network
+
+networks:
+  taskiq-network:
+    driver: bridge
+
+# Optional: Named volume for state persistence
+# volumes:
+#   ministack-data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,9 @@ classifiers = [
 ]
 dependencies = [
     "annotated-types~=0.7.0",
-    "pydantic>=1.0,<=3.0",
+    "pydantic>=2.0,<3.0",
     "aiobotocore>=2.23.1",
+    "anyio>=4.0",
     "taskiq[orjson]>=0.11.12,<1"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
     "pytest~=8.3.3",
     "pytest-asyncio~=0.24.0",
     "pytest-cov~=5.0.0",
-    "localstack~=3.7.2",
+    "ministack~=1.3",
     "types_aiobotocore[essential]>=2.23.1"
 ]
 

--- a/taskiq_aio_sqs/__init__.py
+++ b/taskiq_aio_sqs/__init__.py
@@ -1,4 +1,5 @@
+from taskiq_aio_sqs.queue import SQSQueue
 from taskiq_aio_sqs.s3_backend import S3Backend
 from taskiq_aio_sqs.sqs_broker import SQSBroker
 
-__all__ = ["S3Backend", "SQSBroker"]
+__all__ = ["S3Backend", "SQSBroker", "SQSQueue"]

--- a/taskiq_aio_sqs/queue.py
+++ b/taskiq_aio_sqs/queue.py
@@ -10,7 +10,19 @@ WAIT_TIME_SECONDS = 20
 
 @dataclass(slots=True, kw_only=True, frozen=True)
 class SQSQueue:
-    """Per-queue SQS configuration for SQSBroker."""
+    """Per-queue SQS configuration for SQSBroker.
+
+    Attributes:
+        name: The SQS queue name (or "queue-name.fifo" for FIFO queues).
+        is_fifo: Whether this is a FIFO queue (default: False).
+        max_number_of_messages: Maximum messages to retrieve per poll (1-10,
+            default: 1).
+        wait_time_seconds: Long polling wait time in seconds (0-20, default: 0).
+        visibility_timeout: Optional visibility timeout (in seconds) for received
+            messages. While a message is being processed, it remains invisible to
+            other consumers.
+        options: Optional mapping of additional SQS queue attributes.
+    """
 
     name: str
     is_fifo: bool = False

--- a/taskiq_aio_sqs/queue.py
+++ b/taskiq_aio_sqs/queue.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+MAX_NUMBER_OF_MESSAGES = 10
+WAIT_TIME_SECONDS = 20
+
+
+@dataclass(slots=True, kw_only=True, frozen=True)
+class SQSQueue:
+    """Per-queue SQS configuration for SQSBroker."""
+
+    name: str
+    is_fifo: bool = False
+    max_number_of_messages: int = 1
+    wait_time_seconds: int = 0
+    visibility_timeout: int | None = None
+    options: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not 1 <= self.max_number_of_messages <= MAX_NUMBER_OF_MESSAGES:
+            raise ValueError(
+                f"max_number_of_messages must be between 1 "
+                f"and {MAX_NUMBER_OF_MESSAGES}, got {self.max_number_of_messages}",
+            )
+        if not 0 <= self.wait_time_seconds <= WAIT_TIME_SECONDS:
+            raise ValueError(
+                f"wait_time_seconds must be between 0 and {WAIT_TIME_SECONDS}, "
+                f"got {self.wait_time_seconds}",
+            )
+
+    def __str__(self) -> str:
+        return self.name
+
+    def __hash__(self) -> int:
+        return hash(self.name)

--- a/taskiq_aio_sqs/sqs_broker.py
+++ b/taskiq_aio_sqs/sqs_broker.py
@@ -92,6 +92,9 @@ class SQSBroker(AsyncBroker):
         :param wait_time_seconds: The wait time for long polling.
         :param max_number_of_messages: The maximum number of messages to retrieve
         (0-10).
+        :param visibility_timeout: Optional visibility timeout (in seconds) for received
+        messages. While a message is being processed, it remains invisible to other
+        consumers. If None, uses the queue's default.
         :param delay_seconds: The delay for message delivery (0-900), defatults to 0.
         :param s3_extended_bucket_name: The S3 bucket name for extended storage.
         :param is_fair_queue: Whether the queue is a fair queue, if True, it will use

--- a/taskiq_aio_sqs/sqs_broker.py
+++ b/taskiq_aio_sqs/sqs_broker.py
@@ -11,11 +11,14 @@ from typing import (
     AsyncGenerator,
     Awaitable,
     Callable,
+    Final,
     Generator,
 )
 
+import anyio
 from aiobotocore.session import get_session
 from annotated_types import Ge, Le
+from anyio.streams.memory import MemoryObjectSendStream
 from botocore.exceptions import ClientError
 from pydantic import Field, TypeAdapter
 from taskiq import AsyncBroker
@@ -23,20 +26,20 @@ from taskiq.acks import AckableMessage
 from taskiq.message import BrokerMessage
 
 from taskiq_aio_sqs import constants, exceptions
+from taskiq_aio_sqs.queue import SQSQueue
 
 if TYPE_CHECKING:  # pragma: no cover
     from types_aiobotocore_s3.client import S3Client
     from types_aiobotocore_sqs.client import SQSClient
     from types_aiobotocore_sqs.type_defs import (
         GetQueueUrlResultTypeDef,
-        MessageTypeDef,
         SendMessageBatchRequestEntryTypeDef,
         SendMessageRequestTypeDef,
     )
 
 logger = logging.getLogger(__name__)
 DelaySeconds = TypeAdapter(Annotated[int, Le(900), Ge(0)])
-MaxNumberOfMessages = TypeAdapter(Annotated[int, Le(10), Ge(0)])
+MaxNumberOfMessages = TypeAdapter(Annotated[int, Le(10), Ge(1)])
 BatchSize = TypeAdapter(Annotated[int, Le(10), Ge(1)])
 BatchTimeout = TypeAdapter(Annotated[float, Ge(0.1)])
 # The length of MessageGroupId is 1-128 characters. Valid values: alphanumeric
@@ -51,6 +54,9 @@ MessageGroupId = TypeAdapter(
         ),
     ]
 )
+_QUEUE_LABEL: Final[str] = "queue"
+_LISTEN_STREAM_BUFFER: Final[int] = 100
+_MAX_WAIT_TIME_SECONDS: Final[int] = 20
 
 
 class SQSBroker(AsyncBroker):
@@ -66,6 +72,7 @@ class SQSBroker(AsyncBroker):
         use_task_id_for_deduplication: bool = False,
         wait_time_seconds: int = 10,
         max_number_of_messages: int = 1,
+        visibility_timeout: int | None = None,
         delay_seconds: int = 0,
         s3_extended_bucket_name: str | None = None,
         is_fair_queue: bool = False,
@@ -105,11 +112,13 @@ class SQSBroker(AsyncBroker):
         self._aws_access_key_id = aws_access_key_id
         self._aws_secret_access_key = aws_secret_access_key
         self._aws_endpoint_url = endpoint_url
+        self._session = get_session()
+        self._startup_called = False
+
         self._sqs_queue_name = sqs_queue_name
-        self._is_fifo_queue = True if ".fifo" in sqs_queue_name else False
         self._is_fair_queue = is_fair_queue
         self._sqs_queue_url: str | None = None
-        self._session = get_session()
+        self._queue_urls: dict[str, str] = {}
 
         try:
             self.max_number_of_messages = MaxNumberOfMessages.validate_python(
@@ -130,7 +139,35 @@ class SQSBroker(AsyncBroker):
                 value=delay_seconds,
             ) from None
 
+        if not 0 <= wait_time_seconds <= _MAX_WAIT_TIME_SECONDS:
+            raise exceptions.BrokerInputConfigError(
+                attribute="WaitTimeSeconds",
+                min_number=0,
+                max_number=_MAX_WAIT_TIME_SECONDS,
+                value=wait_time_seconds,
+            )
+
         self.wait_time_seconds = wait_time_seconds
+        self.visibility_timeout = visibility_timeout
+
+        default_queue: SQSQueue
+        try:
+            default_queue = SQSQueue(
+                name=sqs_queue_name,
+                is_fifo=".fifo" in sqs_queue_name,
+                max_number_of_messages=self.max_number_of_messages,
+                wait_time_seconds=self.wait_time_seconds,
+                visibility_timeout=self.visibility_timeout,
+            )
+        except ValueError:
+            raise exceptions.BrokerConfigError(
+                error="Invalid default queue configuration.",
+            ) from None
+
+        self._default_queue = default_queue
+        self._queues: dict[str, SQSQueue] = {default_queue.name: default_queue}
+        self._is_fifo_queue = default_queue.is_fifo
+
         self.use_task_id_for_deduplication = use_task_id_for_deduplication
         self.s3_extended_bucket_name = s3_extended_bucket_name
 
@@ -157,11 +194,42 @@ class SQSBroker(AsyncBroker):
 
         self._skip_batch_tasks = set(skip_batch_tasks or [])
 
+        self._batch_buffers: dict[str, asyncio.Queue[SendMessageRequestTypeDef]] = {}
+        self._batch_tasks: dict[str, asyncio.Task[None]] = {}
+
+        # Backward-compatible aliases for existing tests and integrations.
         self._batch_queue: asyncio.Queue[SendMessageRequestTypeDef] | None = None
-        self._batch_worker_task: asyncio.Task | None = None
+        self._batch_worker_task: asyncio.Task[None] | None = None
+
+    def with_queues(self, *queues: SQSQueue) -> "SQSBroker":
+        """Register additional queues for this broker."""
+        if self._startup_called:
+            raise ValueError("Cannot register queues after startup() has been invoked.")
+
+        for queue in queues:
+            self._queues[queue.name] = queue
+        return self
+
+    def with_default_queue(self, queue: SQSQueue) -> "SQSBroker":
+        """Set the default queue for unlabeled messages."""
+        if self._startup_called:
+            raise ValueError(
+                "Cannot change default queue after startup() has been invoked.",
+            )
+
+        self._default_queue = queue
+        self._queues[queue.name] = queue
+        self._sqs_queue_name = queue.name
+        self._is_fifo_queue = queue.is_fifo
+        self.max_number_of_messages = queue.max_number_of_messages
+        self.wait_time_seconds = queue.wait_time_seconds
+        self.visibility_timeout = queue.visibility_timeout
+        return self
 
     @contextlib.contextmanager
-    def handle_exceptions(self) -> Generator[None, None, None]:
+    def handle_exceptions(
+        self, queue_name: str | None = None
+    ) -> Generator[None, None, None]:
         """Handle exceptions raised by the SQS client."""
         try:
             yield
@@ -171,7 +239,7 @@ class SQSBroker(AsyncBroker):
             error_message = error.get("Message")
             if code == "AWS.SimpleQueueService.NonExistentQueue":
                 raise exceptions.QueueNotFoundError(
-                    queue_name=self._sqs_queue_name,
+                    queue_name=queue_name or self._sqs_queue_name,
                 ) from e
             elif code in ["InvalidParameterValue", "NoSuchBucket"]:
                 raise exceptions.BrokerConfigError(error=error_message) from e
@@ -216,41 +284,87 @@ class SQSBroker(AsyncBroker):
         if self.s3_extended_bucket_name:
             await self._s3_client_context_creator.__aexit__(None, None, None)
 
-    async def _get_queue_url(self) -> str:
-        if not self._sqs_queue_url:
-            with self.handle_exceptions():
-                queue_result: "GetQueueUrlResultTypeDef" = (
-                    await self._sqs_client.get_queue_url(QueueName=self._sqs_queue_name)
-                )
-                self._sqs_queue_url = queue_result["QueueUrl"]
+    async def _get_queue_url(self, queue_name: str | None = None) -> str:
+        resolved_queue_name = queue_name or self._default_queue.name
 
-        return self._sqs_queue_url
+        queue_url = self._queue_urls.get(resolved_queue_name)
+        if queue_url:
+            return queue_url
+
+        with self.handle_exceptions(queue_name=resolved_queue_name):
+            queue_result: "GetQueueUrlResultTypeDef" = (
+                await self._sqs_client.get_queue_url(
+                    QueueName=resolved_queue_name,
+                )
+            )
+
+        queue_url = queue_result["QueueUrl"]
+        self._queue_urls[resolved_queue_name] = queue_url
+        if resolved_queue_name == self._default_queue.name:
+            self._sqs_queue_url = queue_url
+        return queue_url
 
     async def startup(self) -> None:
         """Starts the SQS broker."""
+        self._startup_called = True
         self._sqs_client = await self._get_sqs_client()
         self._s3_client = await self._get_s3_client()
-        await self._get_queue_url()
+
+        for queue in self._queues.values():
+            queue_url = await self._get_queue_url(queue_name=queue.name)
+            self._queue_urls[queue.name] = queue_url
+            logger.info("Resolved queue '%s' URL: %s", queue.name, queue_url)
+
+        self._sqs_queue_url = self._queue_urls.get(self._default_queue.name)
 
         if self._enable_batching:
-            self._batch_queue = asyncio.Queue()
-            self._batch_worker_task = asyncio.create_task(self._batch_worker())
+            self._batch_buffers = {
+                queue_name: asyncio.Queue() for queue_name in self._queues
+            }
+            self._batch_tasks = {
+                queue_name: asyncio.create_task(self._batch_sender(queue_name))
+                for queue_name in self._queues
+            }
+            self._batch_queue = self._batch_buffers.get(self._default_queue.name)
+            self._batch_worker_task = self._batch_tasks.get(self._default_queue.name)
 
         await super().startup()
 
     async def shutdown(self) -> None:
         """Shuts down the SQS broker."""
-        if self._batch_worker_task:
-            self._batch_worker_task.cancel()
+        for batch_task in self._batch_tasks.values():
+            batch_task.cancel()
+        for batch_task in self._batch_tasks.values():
             with contextlib.suppress(asyncio.CancelledError):
-                await self._batch_worker_task
+                await batch_task
+
+        self._batch_tasks = {}
+        self._batch_buffers = {}
+        self._batch_queue = None
+        self._batch_worker_task = None
 
         await self._close_client()
         await super().shutdown()
 
+    def _resolve_queue(self, message: BrokerMessage) -> tuple[str, SQSQueue, str]:
+        queue_name = str(message.labels.get(_QUEUE_LABEL, self._default_queue.name))
+        queue_url = self._queue_urls.get(queue_name)
+        if queue_name == self._default_queue.name and self._sqs_queue_url is not None:
+            queue_url = self._sqs_queue_url
+        if queue_url is None:
+            raise ValueError(
+                f"Queue {queue_name!r} is not registered. "
+                "Call with_queues() before startup.",
+            )
+
+        queue = self._queues[queue_name]
+        return queue_name, queue, queue_url
+
     async def build_kick_kwargs(
         self,
         message: BrokerMessage,
+        queue: SQSQueue | None = None,
+        queue_url: str | None = None,
     ) -> "SendMessageRequestTypeDef":
         """Build the kwargs for the SQS client kick method.
 
@@ -258,10 +372,13 @@ class SQSBroker(AsyncBroker):
         add additional kwargs in the message delivery.
         :param message: BrokerMessage object.
         """
-        queue_url = await self._get_queue_url()
+        resolved_queue = queue or self._default_queue
+        resolved_queue_url = queue_url or await self._get_queue_url(
+            queue_name=resolved_queue.name,
+        )
 
         kwargs: "SendMessageRequestTypeDef" = {
-            "QueueUrl": queue_url,
+            "QueueUrl": resolved_queue_url,
             "MessageBody": message.message.decode("utf-8"),
         }
 
@@ -282,7 +399,7 @@ class SQSBroker(AsyncBroker):
             else:
                 kwargs["DelaySeconds"] = delay_seconds
 
-        if self._is_fifo_queue or self._is_fair_queue:
+        if resolved_queue.is_fifo or self._is_fair_queue:
             group_id_raw = message.labels.get("group_id", message.task_name)
             try:
                 group_id = MessageGroupId.validate_python(group_id_raw)
@@ -295,7 +412,7 @@ class SQSBroker(AsyncBroker):
                 ) from None
             else:
                 kwargs["MessageGroupId"] = group_id
-        if self._is_fifo_queue and self.use_task_id_for_deduplication:
+        if resolved_queue.is_fifo and self.use_task_id_for_deduplication:
             kwargs["MessageDeduplicationId"] = message.task_id
         return kwargs
 
@@ -304,15 +421,24 @@ class SQSBroker(AsyncBroker):
 
         :param message: BrokerMessage object.
         """
-        if (
-            self._enable_batching
-            and self._should_batch_message(message)
-            and self._batch_queue is not None
-        ):
-            kwargs = await self.build_kick_kwargs(message)
-            await self._batch_queue.put(kwargs)
-        else:
-            await self._send_single_message(message)
+        queue_name, queue, queue_url = self._resolve_queue(message)
+
+        if self._enable_batching and self._should_batch_message(message):
+            queue_buffer = self._batch_buffers.get(queue_name)
+            if queue_buffer is not None:
+                kwargs = await self.build_kick_kwargs(
+                    message,
+                    queue=queue,
+                    queue_url=queue_url,
+                )
+                await queue_buffer.put(kwargs)
+                return
+
+        await self._send_single_message(
+            message,
+            queue=queue,
+            queue_url=queue_url,
+        )
 
     def _should_batch_message(self, message: BrokerMessage) -> bool:
         """Determine if a message should be batched or sent immediately."""
@@ -329,10 +455,20 @@ class SQSBroker(AsyncBroker):
         # s3 messages should be batched separately
         return len(message.message) < constants.MAX_SQS_MESSAGE_SIZE
 
-    async def _send_single_message(self, message: BrokerMessage) -> None:
+    async def _send_single_message(
+        self,
+        message: BrokerMessage,
+        queue: SQSQueue | None = None,
+        queue_url: str | None = None,
+    ) -> None:
         """Send a single message immediately (original kick behavior)."""
-        kwargs = await self.build_kick_kwargs(message)
-        with self.handle_exceptions():
+        resolved_queue = queue or self._default_queue
+        kwargs = await self.build_kick_kwargs(
+            message,
+            queue=resolved_queue,
+            queue_url=queue_url,
+        )
+        with self.handle_exceptions(queue_name=resolved_queue.name):
             if len(kwargs["MessageBody"]) >= constants.MAX_SQS_MESSAGE_SIZE:
                 if not self.s3_extended_bucket_name:
                     raise exceptions.ExtendedBucketNameMissingError
@@ -354,8 +490,41 @@ class SQSBroker(AsyncBroker):
 
             await self._sqs_client.send_message(**kwargs)
 
+    async def _batch_sender(self, queue_name: str) -> None:
+        """Background task that processes batched messages for a single queue."""
+        queue_buffer = self._batch_buffers.get(queue_name)
+        if not queue_buffer:
+            raise exceptions.BrokerConfigError(
+                error="Batch worker started but batch queue is not initialized. "
+                "This indicates a broker configuration error."
+            )
+
+        while True:
+            try:
+                batch = await self._collect_batch_for_queue(queue_name)
+                if batch:
+                    await self._send_batch_for_queue(queue_name, batch)
+            except asyncio.CancelledError:
+                # Handle any remaining messages in batch
+                batch = await self._collect_remaining_batch_for_queue(queue_name)
+                if batch:
+                    await self._send_batch_for_queue(queue_name, batch)
+                break
+            except RuntimeError as e:
+                logger.exception(
+                    "Error in batch worker for queue %s: %s",
+                    queue_name,
+                    e,
+                )
+                if "bound to a different event loop" in str(e):
+                    break
+            except Exception as e:
+                logger.exception(
+                    "Error in batch worker for queue %s: %s", queue_name, e
+                )
+
     async def _batch_worker(self) -> None:
-        """Background task that processes batched messages."""
+        """Backward-compatible default queue batch worker implementation."""
         if not self._batch_queue:
             raise exceptions.BrokerConfigError(
                 error="Batch worker started but batch queue is not initialized. "
@@ -368,13 +537,40 @@ class SQSBroker(AsyncBroker):
                 if batch:
                     await self._send_batch(batch)
             except asyncio.CancelledError:
-                # Handle any remaining messages in batch
                 batch = await self._collect_remaining_batch()
                 if batch:
                     await self._send_batch(batch)
                 break
             except Exception as e:
                 logger.exception("Error in batch worker: %s", e)
+
+    async def _collect_batch_for_queue(
+        self,
+        queue_name: str,
+    ) -> list[SendMessageRequestTypeDef]:
+        """Collect a batch of messages up to batch_size or timeout for one queue."""
+        queue_buffer = self._batch_buffers.get(queue_name)
+        batch: list[SendMessageRequestTypeDef] = []
+        deadline = None
+
+        if queue_buffer:
+            while len(batch) < self._batch_size:
+                timeout = self._calculate_timeout(batch, deadline)
+                if timeout is not None and deadline is None and batch:
+                    deadline = time.monotonic() + self._batch_timeout
+
+                try:
+                    if timeout is None:
+                        kwargs = await queue_buffer.get()
+                    else:
+                        kwargs = await asyncio.wait_for(
+                            queue_buffer.get(), timeout=timeout
+                        )
+                    batch.append(kwargs)
+                except asyncio.TimeoutError:
+                    break
+
+        return batch
 
     async def _collect_batch(self) -> list[SendMessageRequestTypeDef]:
         """Collect a batch of messages up to batch_size or timeout."""
@@ -399,7 +595,11 @@ class SQSBroker(AsyncBroker):
 
         return batch
 
-    def _calculate_timeout(self, batch: list, deadline: float | None) -> float | None:
+    def _calculate_timeout(
+        self,
+        batch: list[SendMessageRequestTypeDef],
+        deadline: float | None,
+    ) -> float | None:
         """Calculate timeout for next message wait."""
         if deadline:
             return max(0, deadline - time.monotonic())
@@ -419,16 +619,41 @@ class SQSBroker(AsyncBroker):
                     break
         return batch
 
+    async def _collect_remaining_batch_for_queue(
+        self,
+        queue_name: str,
+    ) -> list[SendMessageRequestTypeDef]:
+        """Collect remaining queued batch messages for one queue on shutdown."""
+        batch: list[SendMessageRequestTypeDef] = []
+        queue_buffer = self._batch_buffers.get(queue_name)
+        if queue_buffer:
+            while not queue_buffer.empty():
+                try:
+                    kwargs = queue_buffer.get_nowait()
+                    batch.append(kwargs)
+                except asyncio.QueueEmpty:
+                    break
+        return batch
+
     async def _send_batch(self, batch: list[SendMessageRequestTypeDef]) -> None:
         """Send a batch of messages to SQS."""
+        await self._send_batch_for_queue(self._default_queue.name, batch)
+
+    async def _send_batch_for_queue(
+        self,
+        queue_name: str,
+        batch: list[SendMessageRequestTypeDef],
+    ) -> None:
+        """Send a batch of messages to a specific queue."""
         if not batch:
             return
 
         # For FIFO queues, we might need to group by MessageGroupId
-        if self._is_fifo_queue:
-            await self._send_fifo_batch(batch)
+        queue = self._queues[queue_name]
+        if queue.is_fifo:
+            await self._send_fifo_batch(queue_name, batch)
         else:
-            await self._send_standard_batch(batch)
+            await self._send_standard_batch(queue_name, batch)
 
     def _build_batch_entries(
         self, batch: list[SendMessageRequestTypeDef]
@@ -453,23 +678,37 @@ class SQSBroker(AsyncBroker):
             entries.append(entry)
         return entries
 
-    async def _send_batch_to_sqs(self, batch: list[SendMessageRequestTypeDef]) -> None:
+    async def _send_batch_to_sqs(
+        self,
+        queue_name: str,
+        batch: list[SendMessageRequestTypeDef],
+    ) -> None:
         """Send a batch of messages to SQS."""
-        queue_url = await self._get_queue_url()
+        queue_url = self._queue_urls.get(queue_name)
+        if queue_url is None:
+            raise exceptions.BrokerConfigError(
+                error=f"Queue {queue_name!r} is missing URL in broker startup state.",
+            )
         entries = self._build_batch_entries(batch)
 
-        with self.handle_exceptions():
+        with self.handle_exceptions(queue_name=queue_name):
             await self._sqs_client.send_message_batch(
                 QueueUrl=queue_url, Entries=entries
             )
 
     async def _send_standard_batch(
-        self, batch: list[SendMessageRequestTypeDef]
+        self,
+        queue_name: str,
+        batch: list[SendMessageRequestTypeDef],
     ) -> None:
         """Send batch for standard queues."""
-        await self._send_batch_to_sqs(batch)
+        await self._send_batch_to_sqs(queue_name, batch)
 
-    async def _send_fifo_batch(self, batch: list[SendMessageRequestTypeDef]) -> None:
+    async def _send_fifo_batch(
+        self,
+        queue_name: str,
+        batch: list[SendMessageRequestTypeDef],
+    ) -> None:
         """Send batch for FIFO queues, preserving order within groups."""
         # Group messages by MessageGroupId to maintain ordering
         groups: dict[str, list[SendMessageRequestTypeDef]] = {}
@@ -481,7 +720,7 @@ class SQSBroker(AsyncBroker):
 
         # Send each group as a separate batch to preserve ordering
         for _, group_messages in groups.items():
-            await self._send_batch_to_sqs(group_messages)
+            await self._send_batch_to_sqs(queue_name, group_messages)
 
     def build_ack_fnx(
         self,
@@ -505,28 +744,80 @@ class SQSBroker(AsyncBroker):
         return ack
 
     async def listen(self) -> AsyncGenerator[AckableMessage, None]:
-        """
-        This function listens to new messages and yields them.
+        """Listen to all configured queues and yield messages from all of them."""
+        send_stream, receive_stream = anyio.create_memory_object_stream[AckableMessage](
+            _LISTEN_STREAM_BUFFER,
+        )
+        stop_event = asyncio.Event()
 
-        :yield: incoming AckableMessages.
-        :return: nothing.
-        """
-        queue_url = await self._get_queue_url()
+        listener_task = asyncio.create_task(
+            self._listen_all_queues(send_stream, stop_event),
+        )
 
-        while True:
-            results = await self._sqs_client.receive_message(
-                QueueUrl=queue_url,
-                MaxNumberOfMessages=self.max_number_of_messages,
-                MessageAttributeNames=["All"],
-                WaitTimeSeconds=self.wait_time_seconds,
+        try:
+            async with receive_stream:
+                async for message in receive_stream:
+                    yield message
+        finally:
+            stop_event.set()
+            await listener_task
+
+    async def _listen_all_queues(
+        self,
+        send_stream: MemoryObjectSendStream[AckableMessage],
+        stop_event: asyncio.Event,
+    ) -> None:
+        """Run all queue listeners inside one fail-fast anyio task group."""
+        async with send_stream, anyio.create_task_group() as task_group:
+            for queue in self._queues.values():
+                task_group.start_soon(
+                    self._listen_single,
+                    queue,
+                    send_stream.clone(),
+                    stop_event,
+                )
+
+    async def _listen_single(
+        self,
+        queue: SQSQueue,
+        send_stream: MemoryObjectSendStream[AckableMessage],
+        stop_event: asyncio.Event,
+    ) -> None:
+        """
+        Listen to a single queue and push received messages into a shared stream.
+
+        :param queue: Queue configuration to poll.
+        :param send_stream: Shared stream used by listen() to fan-in messages.
+        """
+        queue_url = self._queue_urls.get(queue.name)
+        if queue_url is None:
+            raise exceptions.BrokerConfigError(
+                error=f"Queue {queue.name!r} URL was not resolved during startup.",
             )
-            messages: list["MessageTypeDef"] = results.get("Messages", [])
 
-            for message in messages:
-                body = message.get("Body")
-                receipt_handle = message.get("ReceiptHandle")
-                attributes = message.get("MessageAttributes", {})
-                if body and receipt_handle:
+        async with send_stream:
+            while not stop_event.is_set():
+                messages = await self._receive_messages(queue, queue_url)
+
+                if stop_event.is_set():
+                    break
+
+                for message in messages:
+                    if not isinstance(message, dict):
+                        continue
+
+                    body = message.get("Body")
+                    receipt_handle = message.get("ReceiptHandle")
+                    raw_attributes = message.get("MessageAttributes", {})
+                    attributes: dict[str, object]
+                    if isinstance(raw_attributes, dict):
+                        attributes = raw_attributes
+                    else:
+                        attributes = {}
+
+                    if not isinstance(body, str) or not isinstance(receipt_handle, str):
+                        continue
+
                     if attributes.get("s3_extended_message"):
                         loaded_data = json.loads(body)
                         s3_object = await self._s3_client.get_object(
@@ -534,12 +825,51 @@ class SQSBroker(AsyncBroker):
                             Key=loaded_data["s3_key"],
                         )
                         async with s3_object["Body"] as s3_body:
-                            yield AckableMessage(
-                                data=await s3_body.read(),
-                                ack=self.build_ack_fnx(queue_url, receipt_handle),
+                            await send_stream.send(
+                                AckableMessage(
+                                    data=await s3_body.read(),
+                                    ack=self.build_ack_fnx(queue_url, receipt_handle),
+                                ),
                             )
                     else:
-                        yield AckableMessage(
-                            data=body.encode("utf-8"),
-                            ack=self.build_ack_fnx(queue_url, receipt_handle),
+                        await send_stream.send(
+                            AckableMessage(
+                                data=body.encode("utf-8"),
+                                ack=self.build_ack_fnx(queue_url, receipt_handle),
+                            ),
                         )
+
+    async def _receive_messages(
+        self,
+        queue: SQSQueue,
+        queue_url: str,
+    ) -> list[dict[str, object]]:
+        """Poll SQS up to the configured wait budget in small increments."""
+        remaining_wait = queue.wait_time_seconds
+
+        while True:
+            current_wait = 0
+            if remaining_wait > 0:
+                current_wait = min(1, remaining_wait)
+
+            receive_kwargs: dict[str, object] = {
+                "QueueUrl": queue_url,
+                "MaxNumberOfMessages": queue.max_number_of_messages,
+                "MessageAttributeNames": ["All"],
+                "WaitTimeSeconds": current_wait,
+            }
+            if queue.visibility_timeout is not None:
+                receive_kwargs["VisibilityTimeout"] = queue.visibility_timeout
+
+            # Response shape comes from aiobotocore dynamic models.
+            results: dict[str, object] = await self._sqs_client.receive_message(
+                **receive_kwargs,  # type: ignore[arg-type]
+            )
+            messages = results.get("Messages", [])
+            if isinstance(messages, list) and messages:
+                return messages
+
+            if remaining_wait <= 0:
+                return []
+
+            remaining_wait -= current_wait

--- a/taskiq_aio_sqs/sqs_broker.py
+++ b/taskiq_aio_sqs/sqs_broker.py
@@ -363,6 +363,55 @@ class SQSBroker(AsyncBroker):
         queue = self._queues[queue_name]
         return queue_name, queue, queue_url
 
+    def _resolve_delay_seconds(
+        self,
+        message: BrokerMessage,
+        queue: SQSQueue,
+    ) -> int | None:
+        delay_seconds_raw = message.labels.get("delay", self.delay_seconds)
+        if not delay_seconds_raw:
+            return None
+
+        try:
+            if isinstance(delay_seconds_raw, str) and "." in delay_seconds_raw:
+                delay_seconds_raw = float(delay_seconds_raw)
+            if isinstance(delay_seconds_raw, float):
+                delay_seconds_raw = round(delay_seconds_raw)
+            delay_seconds = DelaySeconds.validate_python(delay_seconds_raw)
+        except ValueError:
+            raise exceptions.IntTaskLabelConfigError(
+                attribute="DelaySeconds",
+                min_number=0,
+                max_number=900,
+                value=delay_seconds_raw,
+            ) from None
+
+        if queue.is_fifo:
+            raise exceptions.BrokerConfigError(
+                error="DelaySeconds is not supported for FIFO queues.",
+            )
+
+        return delay_seconds
+
+    def _resolve_message_group_id(
+        self,
+        message: BrokerMessage,
+        queue: SQSQueue,
+    ) -> str | None:
+        if not (queue.is_fifo or self._is_fair_queue):
+            return None
+
+        group_id_raw = message.labels.get("group_id", message.task_name)
+        try:
+            return MessageGroupId.validate_python(group_id_raw)
+        except ValueError:
+            raise exceptions.StrTaskLabelConfigError(
+                attribute="MessageGroupId",
+                min_number=1,
+                max_number=128,
+                value=group_id_raw,
+            ) from None
+
     async def build_kick_kwargs(
         self,
         message: BrokerMessage,
@@ -385,36 +434,14 @@ class SQSBroker(AsyncBroker):
             "MessageBody": message.message.decode("utf-8"),
         }
 
-        if delay_seconds_raw := message.labels.get("delay", self.delay_seconds):
-            try:
-                if isinstance(delay_seconds_raw, str) and "." in delay_seconds_raw:
-                    delay_seconds_raw = float(delay_seconds_raw)
-                if isinstance(delay_seconds_raw, float):
-                    delay_seconds_raw = round(delay_seconds_raw)
-                delay_seconds = DelaySeconds.validate_python(delay_seconds_raw)
-            except ValueError:
-                raise exceptions.IntTaskLabelConfigError(
-                    attribute="DelaySeconds",
-                    min_number=0,
-                    max_number=900,
-                    value=delay_seconds_raw,
-                ) from None
-            else:
-                kwargs["DelaySeconds"] = delay_seconds
+        delay_seconds = self._resolve_delay_seconds(message, resolved_queue)
+        if delay_seconds is not None:
+            kwargs["DelaySeconds"] = delay_seconds
 
-        if resolved_queue.is_fifo or self._is_fair_queue:
-            group_id_raw = message.labels.get("group_id", message.task_name)
-            try:
-                group_id = MessageGroupId.validate_python(group_id_raw)
-            except ValueError:
-                raise exceptions.StrTaskLabelConfigError(
-                    attribute="MessageGroupId",
-                    min_number=1,
-                    max_number=128,
-                    value=group_id_raw,
-                ) from None
-            else:
-                kwargs["MessageGroupId"] = group_id
+        message_group_id = self._resolve_message_group_id(message, resolved_queue)
+        if message_group_id is not None:
+            kwargs["MessageGroupId"] = message_group_id
+
         if resolved_queue.is_fifo and self.use_task_id_for_deduplication:
             kwargs["MessageDeduplicationId"] = message.task_id
         return kwargs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,3 @@
-# NOTE: These fixtures use unique queue names per test instance because the
-# multi-queue listen and retry coverage additions exposed cross-test leakage when
-# LocalStack reuses static queue names during a long full-suite run.
 import uuid
 from typing import Any, AsyncGenerator, TypedDict
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+# NOTE: These fixtures use unique queue names per test instance because the
+# multi-queue listen and retry coverage additions exposed cross-test leakage when
+# LocalStack reuses static queue names during a long full-suite run.
 import uuid
 from typing import Any, AsyncGenerator, TypedDict
 
@@ -17,6 +20,10 @@ EXTENDED_BUCKET = "extendeded-bucket"
 FIFO_QUEUE_NAME = "test-request.fifo"
 
 QUEUE_NAME = "test-request-2"
+
+
+def _queue_name_from_url(queue_url: str) -> str:
+    return queue_url.rsplit("/", maxsplit=1)[-1]
 
 
 class AWSCredentials(TypedDict):
@@ -59,8 +66,9 @@ async def s3_client(aws_credentials: AWSCredentials) -> AsyncGenerator[S3Client,
 
 @pytest.fixture(scope="function")
 async def fifo_sqs_queue(sqs_client: SQSClient) -> AsyncGenerator[str, Any]:
+    queue_name = f"test-request-{uuid.uuid4().hex}.fifo"
     response = await sqs_client.create_queue(
-        QueueName=FIFO_QUEUE_NAME,
+        QueueName=queue_name,
         Attributes={"FifoQueue": "true"},
     )
     queue_url = response["QueueUrl"]
@@ -70,7 +78,8 @@ async def fifo_sqs_queue(sqs_client: SQSClient) -> AsyncGenerator[str, Any]:
 
 @pytest.fixture(scope="function")
 async def sqs_queue(sqs_client: SQSClient) -> AsyncGenerator[str, Any]:
-    response = await sqs_client.create_queue(QueueName=QUEUE_NAME)
+    queue_name = f"{QUEUE_NAME}-{uuid.uuid4().hex}"
+    response = await sqs_client.create_queue(QueueName=queue_name)
     queue_url = response["QueueUrl"]
     yield queue_url
     await sqs_client.delete_queue(QueueUrl=queue_url)
@@ -129,7 +138,7 @@ async def sqs_broker(
     sqs_queue: str,
 ) -> AsyncGenerator[SQSBroker, Any]:
     broker = SQSBroker(
-        sqs_queue_name=QUEUE_NAME,
+        sqs_queue_name=_queue_name_from_url(sqs_queue),
         s3_extended_bucket_name=EXTENDED_BUCKET,
         **aws_credentials,
     )
@@ -147,7 +156,7 @@ async def sqs_broker_fifo(
     fifo_sqs_queue: str,
 ) -> AsyncGenerator[SQSBroker, Any]:
     broker = SQSBroker(
-        sqs_queue_name=FIFO_QUEUE_NAME,
+        sqs_queue_name=_queue_name_from_url(fifo_sqs_queue),
         use_task_id_for_deduplication=True,
         **aws_credentials,
     )
@@ -164,7 +173,7 @@ async def sqs_broker_fair(
     sqs_queue: str,
 ) -> AsyncGenerator[SQSBroker, Any]:
     broker = SQSBroker(
-        sqs_queue_name=QUEUE_NAME,
+        sqs_queue_name=_queue_name_from_url(sqs_queue),
         s3_extended_bucket_name=EXTENDED_BUCKET,
         is_fair_queue=True,
         **aws_credentials,
@@ -183,7 +192,7 @@ async def sqs_broker_fifo_no_dedup(
     fifo_sqs_queue: str,
 ) -> AsyncGenerator[SQSBroker, Any]:
     broker = SQSBroker(
-        sqs_queue_name=FIFO_QUEUE_NAME,
+        sqs_queue_name=_queue_name_from_url(fifo_sqs_queue),
         use_task_id_for_deduplication=False,
         **aws_credentials,
     )
@@ -200,7 +209,7 @@ async def sqs_broker_with_delay_seconds(
     sqs_queue: str,
 ) -> AsyncGenerator[SQSBroker, Any]:
     broker = SQSBroker(
-        sqs_queue_name=QUEUE_NAME,
+        sqs_queue_name=_queue_name_from_url(sqs_queue),
         use_task_id_for_deduplication=False,
         delay_seconds=2,
         **aws_credentials,
@@ -232,7 +241,7 @@ async def sqs_broker_with_backend(
     s3_backend: S3Backend,
 ) -> AsyncGenerator[SQSBroker, Any]:
     broker = SQSBroker(
-        sqs_queue_name=QUEUE_NAME,
+        sqs_queue_name=_queue_name_from_url(sqs_queue),
         use_task_id_for_deduplication=False,
         delay_seconds=2,
         **aws_credentials,
@@ -253,7 +262,7 @@ async def batching_broker(
 ) -> AsyncGenerator[SQSBroker, None]:
     """Create a broker with batching enabled."""
     broker = SQSBroker(
-        sqs_queue_name=QUEUE_NAME,
+        sqs_queue_name=_queue_name_from_url(sqs_queue),
         enable_batching=True,
         batch_size=3,
         batch_timeout=0.5,
@@ -271,7 +280,7 @@ async def batching_broker_with_delay(
 ) -> AsyncGenerator[SQSBroker, None]:
     """Create a broker with batching and global delay enabled."""
     broker = SQSBroker(
-        sqs_queue_name=QUEUE_NAME,
+        sqs_queue_name=_queue_name_from_url(sqs_queue),
         enable_batching=True,
         batch_size=3,
         batch_timeout=0.5,
@@ -290,7 +299,7 @@ async def batching_broker_fifo(
 ) -> AsyncGenerator[SQSBroker, None]:
     """Create a FIFO broker with batching enabled."""
     broker = SQSBroker(
-        sqs_queue_name=FIFO_QUEUE_NAME,
+        sqs_queue_name=_queue_name_from_url(fifo_sqs_queue),
         enable_batching=True,
         batch_size=3,
         batch_timeout=0.5,
@@ -309,7 +318,7 @@ async def batching_broker_with_skip_tasks(
 ) -> AsyncGenerator[SQSBroker, None]:
     """Create a broker with batching enabled and skip_batch_tasks configured."""
     broker = SQSBroker(
-        sqs_queue_name=QUEUE_NAME,
+        sqs_queue_name=_queue_name_from_url(sqs_queue),
         enable_batching=True,
         batch_size=3,
         batch_timeout=0.5,
@@ -329,7 +338,7 @@ async def batching_broker_with_s3(
 ) -> AsyncGenerator[SQSBroker, None]:
     """Create a broker with batching enabled and S3 extended storage."""
     broker = SQSBroker(
-        sqs_queue_name=QUEUE_NAME,
+        sqs_queue_name=_queue_name_from_url(sqs_queue),
         enable_batching=True,
         batch_size=3,
         batch_timeout=0.5,
@@ -368,7 +377,7 @@ def delayed_broker_message() -> BrokerMessage:
         task_id=task,
         task_name="test_task",
         message=b"test_message",
-        labels={"delay": "2"},
+        labels={"delay": "1"},
     )
 
 

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -19,6 +19,10 @@ from taskiq_aio_sqs.exceptions import (
 from tests.conftest import QUEUE_NAME, AWSCredentials
 
 
+def queue_name_from_url(queue_url: str) -> str:
+    return queue_url.rsplit("/", maxsplit=1)[-1]
+
+
 def create_test_message(task_name: str = "test_task", **labels: Any) -> BrokerMessage:
     """Create a test message with optional labels."""
     return BrokerMessage(
@@ -298,7 +302,7 @@ async def test_batch_worker_normal_initialization(
 ) -> None:
     """Test that batch worker works normally when properly initialized."""
     broker = SQSBroker(
-        sqs_queue_name=QUEUE_NAME,
+        sqs_queue_name=queue_name_from_url(sqs_queue),
         enable_batching=True,
         **aws_credentials,
     )
@@ -463,7 +467,7 @@ async def test_disabled_batching_fallback(
 ) -> None:
     """Test that when batching is disabled, messages are sent individually."""
     broker = SQSBroker(
-        sqs_queue_name=QUEUE_NAME,
+        sqs_queue_name=queue_name_from_url(sqs_queue),
         enable_batching=False,  # Disabled
         **aws_credentials,
     )

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -195,23 +195,29 @@ async def test_batch_with_global_delay(
     batching_broker_with_delay: SQSBroker,
     sqs_queue: str,
 ) -> None:
-    """Test that batching works with global delay settings."""
+    """Test that global delay is propagated to batch entries."""
     messages = [create_test_message() for _ in range(3)]
+
+    original_send_batch = batching_broker_with_delay._sqs_client.send_message_batch
+    captured_entries: list[dict[str, Any]] = []
+
+    async def capture_send_batch(**kwargs: Any) -> Any:
+        entries = kwargs.get("Entries", [])
+        if isinstance(entries, list):
+            captured_entries.extend(entries)
+        return await original_send_batch(**kwargs)
+
+    batching_broker_with_delay._sqs_client.send_message_batch = AsyncMock(  # type: ignore[method-assign]
+        side_effect=capture_send_batch,
+    )
 
     for message in messages:
         await batching_broker_with_delay.kick(message)
 
-    await asyncio.sleep(0.1)  # Let batch process
+    await asyncio.sleep(0.7)  # Let batch process
 
-    response = await batching_broker_with_delay._sqs_client.receive_message(
-        QueueUrl=sqs_queue,
-        MaxNumberOfMessages=10,
-        WaitTimeSeconds=1,
-    )
-
-    # Messages won't be immediately available due to delay
-    # This tests that the batching respected the delays
-    assert len(response.get("Messages", [])) == 0
+    assert len(captured_entries) == 3
+    assert all(entry.get("DelaySeconds") == 2 for entry in captured_entries)
 
     response = await batching_broker_with_delay._sqs_client.receive_message(
         QueueUrl=sqs_queue,

--- a/tests/test_kick.py
+++ b/tests/test_kick.py
@@ -93,6 +93,10 @@ async def test_kick_fifo_queue(
     fifo_sqs_queue: str,
     broker_message: BrokerMessage,
 ) -> None:
+    kwargs = await sqs_broker_fifo.build_kick_kwargs(broker_message)
+    message_group_id = kwargs.get("MessageGroupId")
+    assert message_group_id == "test_task"
+
     await sqs_broker_fifo.kick(broker_message)
 
     response = await sqs_broker_fifo._sqs_client.receive_message(
@@ -103,7 +107,6 @@ async def test_kick_fifo_queue(
     assert "Messages" in response
     assert len(response["Messages"]) == 1
     assert response["Messages"][0]["Body"] == "test_message"  # type: ignore
-    assert response["Messages"][0]["Attributes"]["MessageGroupId"] == "test_task"  # type: ignore
 
 
 @pytest.mark.asyncio
@@ -112,6 +115,10 @@ async def test_kick_fifo_queue_custom_group(
     fifo_sqs_queue: str,
     grouped_broker_message: BrokerMessage,
 ) -> None:
+    kwargs = await sqs_broker_fifo.build_kick_kwargs(grouped_broker_message)
+    message_group_id = kwargs.get("MessageGroupId")
+    assert message_group_id == "test_group"
+
     await sqs_broker_fifo.kick(grouped_broker_message)
 
     response = await sqs_broker_fifo._sqs_client.receive_message(
@@ -122,7 +129,6 @@ async def test_kick_fifo_queue_custom_group(
     assert "Messages" in response
     assert len(response["Messages"]) == 1
     assert response["Messages"][0]["Body"] == "test_message"  # type: ignore
-    assert response["Messages"][0]["Attributes"]["MessageGroupId"] == "test_group"  # type: ignore
 
 
 @pytest.mark.asyncio

--- a/tests/test_multiqueue.py
+++ b/tests/test_multiqueue.py
@@ -773,3 +773,27 @@ async def test_receive_messages_includes_visibility_timeout() -> None:
         WaitTimeSeconds=0,
         VisibilityTimeout=7,
     )
+
+
+@pytest.mark.anyio
+async def test_task_decorator_delay_parameter_works(
+    single_queue_broker: SQSBroker,
+) -> None:
+    """Test that @broker.task(delay=N) decorator parameter works."""
+    # Mock the SQS client to verify DelaySeconds is passed
+    original_send_message = single_queue_broker._sqs_client.send_message
+    send_message_mock = AsyncMock(wraps=original_send_message)
+    single_queue_broker._sqs_client.send_message = send_message_mock  # type: ignore[method-assign]
+
+    # Define a task using the decorator with delay parameter
+    @single_queue_broker.task(delay="5")
+    async def delayed_task() -> str:
+        return "delayed"
+
+    # Kick the task
+    await delayed_task.kiq()
+
+    # Verify send_message was called with DelaySeconds
+    send_message_mock.assert_awaited()
+    call_kwargs = send_message_mock.call_args.kwargs
+    assert call_kwargs.get("DelaySeconds") == 5

--- a/tests/test_multiqueue.py
+++ b/tests/test_multiqueue.py
@@ -1,0 +1,775 @@
+import asyncio
+from collections.abc import AsyncGenerator
+from dataclasses import FrozenInstanceError
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import anyio
+import pytest
+from botocore.exceptions import ClientError
+from taskiq import BrokerMessage
+from taskiq.acks import AckableMessage
+from types_aiobotocore_s3.client import S3Client
+from types_aiobotocore_sqs.client import SQSClient
+
+from taskiq_aio_sqs import SQSBroker, SQSQueue
+from taskiq_aio_sqs.exceptions import (
+    BrokerConfigError,
+    BrokerInputConfigError,
+    SQSBrokerError,
+)
+from tests.conftest import AWSCredentials
+
+
+@pytest.fixture
+def default_queue() -> SQSQueue:
+    return SQSQueue(name="taskiq-default")
+
+
+@pytest.fixture
+def critical_queue() -> SQSQueue:
+    return SQSQueue(name="taskiq-critical")
+
+
+@pytest.fixture
+def fifo_queue() -> SQSQueue:
+    return SQSQueue(name="taskiq-fifo.fifo", is_fifo=True)
+
+
+@pytest.fixture
+async def multi_queue_broker(
+    aws_credentials: AWSCredentials,
+    sqs_client: SQSClient,
+    default_queue: SQSQueue,
+    critical_queue: SQSQueue,
+    fifo_queue: SQSQueue,
+) -> AsyncGenerator[SQSBroker, None]:
+    created_queue_urls: list[str] = []
+
+    default_response = await sqs_client.create_queue(QueueName=default_queue.name)
+    created_queue_urls.append(default_response["QueueUrl"])
+
+    critical_response = await sqs_client.create_queue(QueueName=critical_queue.name)
+    created_queue_urls.append(critical_response["QueueUrl"])
+
+    fifo_response = await sqs_client.create_queue(
+        QueueName=fifo_queue.name,
+        Attributes={
+            "FifoQueue": "true",
+            "ContentBasedDeduplication": "true",
+        },
+    )
+    created_queue_urls.append(fifo_response["QueueUrl"])
+
+    broker = SQSBroker(sqs_queue_name=default_queue.name, **aws_credentials)
+    broker.with_queues(critical_queue, fifo_queue)
+    broker.with_default_queue(default_queue)
+    await broker.startup()
+
+    try:
+        yield broker
+    finally:
+        await broker.shutdown()
+        for queue_url in created_queue_urls:
+            await sqs_client.delete_queue(QueueUrl=queue_url)
+
+
+@pytest.fixture
+async def single_queue_broker(
+    aws_credentials: AWSCredentials,
+    sqs_client: SQSClient,
+    default_queue: SQSQueue,
+) -> AsyncGenerator[SQSBroker, None]:
+    response = await sqs_client.create_queue(QueueName=default_queue.name)
+    queue_url = response["QueueUrl"]
+
+    broker = SQSBroker(sqs_queue_name=default_queue.name, **aws_credentials)
+    await broker.startup()
+
+    try:
+        yield broker
+    finally:
+        await broker.shutdown()
+        await sqs_client.delete_queue(QueueUrl=queue_url)
+
+
+@pytest.fixture
+async def batching_multi_queue_broker(
+    aws_credentials: AWSCredentials,
+    sqs_client: SQSClient,
+    default_queue: SQSQueue,
+    critical_queue: SQSQueue,
+) -> AsyncGenerator[SQSBroker, None]:
+    default_response = await sqs_client.create_queue(QueueName=default_queue.name)
+    critical_response = await sqs_client.create_queue(QueueName=critical_queue.name)
+
+    broker = SQSBroker(
+        sqs_queue_name=default_queue.name,
+        enable_batching=True,
+        batch_size=3,
+        batch_timeout=0.2,
+        **aws_credentials,
+    )
+    broker.with_queues(critical_queue)
+    await broker.startup()
+
+    try:
+        yield broker
+    finally:
+        await broker.shutdown()
+        await sqs_client.delete_queue(QueueUrl=default_response["QueueUrl"])
+        await sqs_client.delete_queue(QueueUrl=critical_response["QueueUrl"])
+
+
+def _message(
+    body: bytes,
+    task_name: str = "test_task",
+    **labels: str,
+) -> BrokerMessage:
+    return BrokerMessage(
+        task_id=f"{task_name}-id",
+        task_name=task_name,
+        message=body,
+        labels=labels,
+    )
+
+
+@pytest.mark.anyio
+async def test_with_queues_registers_all_queues(multi_queue_broker: SQSBroker) -> None:
+    assert "taskiq-default" in multi_queue_broker._queue_urls
+    assert "taskiq-critical" in multi_queue_broker._queue_urls
+    assert "taskiq-fifo.fifo" in multi_queue_broker._queue_urls
+
+
+@pytest.mark.anyio
+async def test_with_default_queue_sets_default(critical_queue: SQSQueue) -> None:
+    broker = SQSBroker(sqs_queue_name="taskiq-default")
+    broker.with_default_queue(critical_queue)
+
+    assert broker._default_queue == critical_queue
+
+
+@pytest.mark.anyio
+async def test_with_queues_raises_after_startup(
+    multi_queue_broker: SQSBroker,
+) -> None:
+    with pytest.raises(ValueError):
+        multi_queue_broker.with_queues(SQSQueue(name="another-queue"))
+
+
+@pytest.mark.anyio
+async def test_unknown_queue_name_raises_on_kick(
+    multi_queue_broker: SQSBroker,
+) -> None:
+    multi_queue_broker._sqs_client.send_message = AsyncMock()  # type: ignore[method-assign]
+
+    with pytest.raises(ValueError):
+        await multi_queue_broker.kick(_message(b"bad", queue="nonexistent"))
+
+    multi_queue_broker._sqs_client.send_message.assert_not_called()
+
+
+def test_invalid_max_number_of_messages_raises() -> None:
+    with pytest.raises(ValueError):
+        SQSQueue(name="bad", max_number_of_messages=0)
+    with pytest.raises(ValueError):
+        SQSQueue(name="bad", max_number_of_messages=11)
+
+
+@pytest.mark.anyio
+async def test_kick_routes_to_default_queue_when_no_label(
+    multi_queue_broker: SQSBroker,
+) -> None:
+    await multi_queue_broker.kick(_message(b"from-default"))
+
+    default_response = await multi_queue_broker._sqs_client.receive_message(
+        QueueUrl=multi_queue_broker._queue_urls["taskiq-default"],
+        WaitTimeSeconds=1,
+    )
+    critical_response = await multi_queue_broker._sqs_client.receive_message(
+        QueueUrl=multi_queue_broker._queue_urls["taskiq-critical"],
+        WaitTimeSeconds=1,
+    )
+
+    assert "Messages" in default_response
+    assert default_response["Messages"][0]["Body"] == "from-default"  # type: ignore[typeddict-item]
+    assert "Messages" not in critical_response
+
+
+@pytest.mark.anyio
+async def test_kick_routes_to_named_queue_via_label(
+    multi_queue_broker: SQSBroker,
+) -> None:
+    await multi_queue_broker.kick(
+        _message(b"from-critical", queue="taskiq-critical"),
+    )
+
+    critical_response = await multi_queue_broker._sqs_client.receive_message(
+        QueueUrl=multi_queue_broker._queue_urls["taskiq-critical"],
+        WaitTimeSeconds=1,
+    )
+    assert "Messages" in critical_response
+    assert critical_response["Messages"][0]["Body"] == "from-critical"  # type: ignore[typeddict-item]
+
+
+@pytest.mark.anyio
+async def test_task_decorator_queue_label_routes_correctly(
+    multi_queue_broker: SQSBroker,
+) -> None:
+    @multi_queue_broker.task(queue="taskiq-critical")
+    async def critical_task() -> None:
+        return None
+
+    await critical_task.kiq()
+
+    critical_response = await multi_queue_broker._sqs_client.receive_message(
+        QueueUrl=multi_queue_broker._queue_urls["taskiq-critical"],
+        WaitTimeSeconds=1,
+    )
+    default_response = await multi_queue_broker._sqs_client.receive_message(
+        QueueUrl=multi_queue_broker._queue_urls["taskiq-default"],
+        WaitTimeSeconds=1,
+    )
+
+    assert "Messages" in critical_response
+    assert "Messages" not in default_response
+
+
+@pytest.mark.anyio
+async def test_kick_to_fifo_queue(
+    multi_queue_broker: SQSBroker,
+) -> None:
+    await multi_queue_broker.kick(
+        _message(
+            b"fifo-data",
+            queue="taskiq-fifo.fifo",
+            group_id="group-1",
+        ),
+    )
+
+    fifo_response = await multi_queue_broker._sqs_client.receive_message(
+        QueueUrl=multi_queue_broker._queue_urls["taskiq-fifo.fifo"],
+        WaitTimeSeconds=1,
+        MessageSystemAttributeNames=["MessageGroupId"],
+    )
+
+    assert "Messages" in fifo_response
+    assert fifo_response["Messages"][0]["Body"] == "fifo-data"  # type: ignore[typeddict-item]
+
+
+@pytest.mark.anyio
+async def test_listen_receives_from_all_queues(
+    multi_queue_broker: SQSBroker,
+) -> None:
+    await multi_queue_broker.kick(_message(b"from-default"))
+    await multi_queue_broker.kick(_message(b"from-critical", queue="taskiq-critical"))
+
+    received: set[str] = set()
+    async for item in multi_queue_broker.listen():
+        assert isinstance(item, AckableMessage)
+        received.add(item.data.decode("utf-8"))
+        assert item.ack is not None
+        await cast(Any, item.ack)()
+        if len(received) == 2:
+            break
+
+    assert received == {"from-default", "from-critical"}
+
+
+@pytest.mark.anyio
+async def test_listen_single_queue_isolation(
+    aws_credentials: AWSCredentials,
+    sqs_client: SQSClient,
+    default_queue: SQSQueue,
+    critical_queue: SQSQueue,
+) -> None:
+    default_response = await sqs_client.create_queue(QueueName=default_queue.name)
+    critical_response = await sqs_client.create_queue(QueueName=critical_queue.name)
+
+    broker = SQSBroker(sqs_queue_name=default_queue.name, **aws_credentials)
+    await broker.startup()
+
+    try:
+        await sqs_client.send_message(
+            QueueUrl=critical_response["QueueUrl"],
+            MessageBody="critical-only",
+        )
+
+        with pytest.raises(TimeoutError):
+            with anyio.fail_after(1):
+                async for item in broker.listen():
+                    if isinstance(item, AckableMessage):
+                        assert item.ack is not None
+                        await cast(Any, item.ack)()
+                    break
+    finally:
+        await broker.shutdown()
+        await sqs_client.delete_queue(QueueUrl=default_response["QueueUrl"])
+        await sqs_client.delete_queue(QueueUrl=critical_response["QueueUrl"])
+
+
+@pytest.mark.anyio
+async def test_single_queue_broker_behaves_as_before(
+    single_queue_broker: SQSBroker,
+) -> None:
+    await single_queue_broker.kick(_message(b"single-queue-message"))
+
+    async for item in single_queue_broker.listen():
+        assert isinstance(item, AckableMessage)
+        assert item.data == b"single-queue-message"
+        assert item.ack is not None
+        await cast(Any, item.ack)()
+        break
+
+
+@pytest.mark.anyio
+async def test_batching_routes_per_queue(
+    batching_multi_queue_broker: SQSBroker,
+) -> None:
+    await batching_multi_queue_broker.kick(_message(b"batch-default"))
+    await batching_multi_queue_broker.kick(
+        _message(b"batch-critical", queue="taskiq-critical"),
+    )
+
+    await anyio.sleep(0.4)
+
+    default_response = await batching_multi_queue_broker._sqs_client.receive_message(
+        QueueUrl=batching_multi_queue_broker._queue_urls["taskiq-default"],
+        WaitTimeSeconds=1,
+    )
+    critical_response = await batching_multi_queue_broker._sqs_client.receive_message(
+        QueueUrl=batching_multi_queue_broker._queue_urls["taskiq-critical"],
+        WaitTimeSeconds=1,
+    )
+
+    assert "Messages" in default_response
+    assert default_response["Messages"][0]["Body"] == "batch-default"  # type: ignore[typeddict-item]
+    assert "Messages" in critical_response
+    assert critical_response["Messages"][0]["Body"] == "batch-critical"  # type: ignore[typeddict-item]
+
+
+def test_sqs_queue_str_returns_name(default_queue: SQSQueue) -> None:
+    assert str(default_queue) == "taskiq-default"
+
+
+def test_sqs_queue_hash_based_on_name() -> None:
+    left = SQSQueue(name="same")
+    right = SQSQueue(name="same", is_fifo=True)
+
+    assert hash(left) == hash(right)
+
+
+def test_sqs_queue_frozen(default_queue: SQSQueue) -> None:
+    with pytest.raises(FrozenInstanceError):
+        default_queue.name = "new-name"  # type: ignore[misc]
+
+
+def test_sqs_queue_max_messages_boundary_values() -> None:
+    SQSQueue(name="min-ok", max_number_of_messages=1)
+    SQSQueue(name="max-ok", max_number_of_messages=10)
+
+    with pytest.raises(ValueError):
+        SQSQueue(name="under", max_number_of_messages=0)
+    with pytest.raises(ValueError):
+        SQSQueue(name="over", max_number_of_messages=11)
+
+
+def test_sqs_queue_wait_time_boundary_values() -> None:
+    SQSQueue(name="min-ok", wait_time_seconds=0)
+    SQSQueue(name="max-ok", wait_time_seconds=20)
+
+    with pytest.raises(ValueError):
+        SQSQueue(name="under", wait_time_seconds=-1)
+    with pytest.raises(ValueError):
+        SQSQueue(name="over", wait_time_seconds=21)
+
+
+def test_wait_time_seconds_validation_raises() -> None:
+    with pytest.raises(BrokerInputConfigError):
+        SQSBroker(sqs_queue_name="taskiq-default", wait_time_seconds=21)
+
+
+@pytest.mark.anyio
+async def test_with_default_queue_raises_after_startup(
+    multi_queue_broker: SQSBroker,
+) -> None:
+    with pytest.raises(ValueError):
+        multi_queue_broker.with_default_queue(SQSQueue(name="late-default"))
+
+
+@pytest.mark.anyio
+async def test_get_queue_url_returns_cached_value() -> None:
+    broker = SQSBroker(sqs_queue_name="taskiq-default")
+    broker._queue_urls["taskiq-default"] = "cached-url"
+
+    assert await broker._get_queue_url() == "cached-url"
+
+
+def test_handle_exceptions_wraps_unknown_client_error() -> None:
+    broker = SQSBroker(sqs_queue_name="taskiq-default")
+
+    with pytest.raises(SQSBrokerError), broker.handle_exceptions():
+        raise ClientError(
+            {"Error": {"Code": "Boom", "Message": "broken"}},
+            "SendMessage",
+        )
+
+
+@pytest.mark.anyio
+async def test_batch_sender_raises_when_queue_missing() -> None:
+    broker = SQSBroker(sqs_queue_name="taskiq-default", enable_batching=True)
+
+    with pytest.raises(BrokerConfigError):
+        await broker._batch_sender("taskiq-default")
+
+
+@pytest.mark.anyio
+async def test_batch_sender_sends_remaining_messages_on_cancel() -> None:
+    broker = SQSBroker(sqs_queue_name="taskiq-default", enable_batching=True)
+    broker._batch_buffers["taskiq-default"] = asyncio.Queue()
+    broker._collect_batch_for_queue = AsyncMock(side_effect=asyncio.CancelledError())  # type: ignore[method-assign]
+    broker._collect_remaining_batch_for_queue = AsyncMock(  # type: ignore[method-assign]
+        return_value=[{"QueueUrl": "url", "MessageBody": "payload"}],
+    )
+    broker._send_batch_for_queue = AsyncMock()  # type: ignore[method-assign]
+
+    await broker._batch_sender("taskiq-default")
+
+    broker._send_batch_for_queue.assert_awaited_once_with(
+        "taskiq-default",
+        [{"QueueUrl": "url", "MessageBody": "payload"}],
+    )
+
+
+@pytest.mark.anyio
+async def test_batch_sender_breaks_on_cross_loop_runtime_error() -> None:
+    broker = SQSBroker(sqs_queue_name="taskiq-default", enable_batching=True)
+    broker._batch_buffers["taskiq-default"] = asyncio.Queue()
+    broker._collect_batch_for_queue = AsyncMock(  # type: ignore[method-assign]
+        side_effect=RuntimeError("bound to a different event loop"),
+    )
+
+    await broker._batch_sender("taskiq-default")
+
+
+@pytest.mark.anyio
+async def test_batch_worker_logs_exception_and_continues() -> None:
+    broker = SQSBroker(sqs_queue_name="taskiq-default", enable_batching=True)
+    broker._batch_queue = asyncio.Queue()
+    broker._collect_batch = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[Exception("boom"), asyncio.CancelledError()],
+    )
+    broker._collect_remaining_batch = AsyncMock(return_value=[])  # type: ignore[method-assign]
+    broker._send_batch = AsyncMock()  # type: ignore[method-assign]
+
+    await broker._batch_worker()
+
+    broker._collect_remaining_batch.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_collect_batch_returns_buffered_message() -> None:
+    broker = SQSBroker(sqs_queue_name="taskiq-default", enable_batching=True)
+    broker._batch_queue = asyncio.Queue()
+    await broker._batch_queue.put({"QueueUrl": "url", "MessageBody": "payload"})
+
+    batch = await broker._collect_batch()
+
+    assert batch == [{"QueueUrl": "url", "MessageBody": "payload"}]
+
+
+def test_calculate_timeout_with_deadline() -> None:
+    broker = SQSBroker(sqs_queue_name="taskiq-default", enable_batching=True)
+    deadline = 1.0
+
+    assert broker._calculate_timeout([], None) is None
+    assert (
+        broker._calculate_timeout(
+            [{"QueueUrl": "url", "MessageBody": "x"}],
+            None,
+        )
+        == broker._batch_timeout
+    )
+    calculated_timeout = broker._calculate_timeout([], deadline)
+    assert calculated_timeout is not None
+    assert calculated_timeout <= deadline
+
+
+@pytest.mark.anyio
+async def test_collect_remaining_batch_for_queue_collects_messages() -> None:
+    broker = SQSBroker(sqs_queue_name="taskiq-default", enable_batching=True)
+    queue_name = "taskiq-default"
+    broker._batch_buffers[queue_name] = asyncio.Queue()
+    await broker._batch_buffers[queue_name].put(
+        {"QueueUrl": "url", "MessageBody": "one"}
+    )
+    await broker._batch_buffers[queue_name].put(
+        {"QueueUrl": "url", "MessageBody": "two"}
+    )
+
+    batch = await broker._collect_remaining_batch_for_queue(queue_name)
+
+    assert batch == [
+        {"QueueUrl": "url", "MessageBody": "one"},
+        {"QueueUrl": "url", "MessageBody": "two"},
+    ]
+
+
+@pytest.mark.anyio
+async def test_send_batch_to_sqs_raises_without_queue_url() -> None:
+    broker = SQSBroker(sqs_queue_name="taskiq-default", enable_batching=True)
+
+    with pytest.raises(BrokerConfigError):
+        await broker._send_batch_to_sqs(
+            "missing",
+            [{"QueueUrl": "url", "MessageBody": "payload"}],
+        )
+
+
+def test_invalid_default_queue_config_raises_broker_config_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Line 162-163: ValueError from SQSQueue raises BrokerConfigError."""
+    import taskiq_aio_sqs.sqs_broker as _mod
+
+    original = _mod.SQSQueue
+
+    def _raise(*args: object, **kwargs: object) -> None:  # type: ignore[return]
+        raise ValueError("injected")
+
+    monkeypatch.setattr(_mod, "SQSQueue", _raise)
+    with pytest.raises(BrokerConfigError, match="Invalid default queue configuration"):
+        SQSBroker(sqs_queue_name="taskiq-default")
+
+    monkeypatch.setattr(_mod, "SQSQueue", original)
+
+
+@pytest.mark.anyio
+async def test_batch_sender_logs_generic_exception_and_continues() -> None:
+    """521-522: generic Exception in _batch_sender is logged and loop continues."""
+    broker = SQSBroker(sqs_queue_name="taskiq-default", enable_batching=True)
+    broker._batch_buffers["taskiq-default"] = asyncio.Queue()
+    broker._collect_batch_for_queue = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[OSError("network error"), asyncio.CancelledError()],
+    )
+    broker._collect_remaining_batch_for_queue = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+    await broker._batch_sender("taskiq-default")
+
+
+@pytest.mark.anyio
+async def test_batch_worker_sends_batch_in_happy_path() -> None:
+    """Lines 537-538: _batch_worker sends a non-empty batch successfully."""
+    broker = SQSBroker(sqs_queue_name="taskiq-default", enable_batching=True)
+    broker._batch_queue = asyncio.Queue()
+    broker._collect_batch = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            [{"QueueUrl": "url", "MessageBody": "hello"}],
+            asyncio.CancelledError(),
+        ],
+    )
+    broker._send_batch = AsyncMock()  # type: ignore[method-assign]
+    broker._collect_remaining_batch = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+    await broker._batch_worker()
+
+    broker._send_batch.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_collect_remaining_batch_for_queue_handles_queue_empty() -> None:
+    """Lines 634-635: QueueEmpty is caught when queue empties mid-drain."""
+    broker = SQSBroker(sqs_queue_name="taskiq-default", enable_batching=True)
+    queue_name = "taskiq-default"
+    mock_queue = AsyncMock(spec=asyncio.Queue)
+    mock_queue.empty.return_value = False  # always reports non-empty
+    mock_queue.get_nowait.side_effect = asyncio.QueueEmpty()  # but raises immediately
+    broker._batch_buffers[queue_name] = mock_queue
+
+    batch = await broker._collect_remaining_batch_for_queue(queue_name)
+
+    assert batch == []
+
+
+@pytest.mark.anyio
+async def test_listen_single_breaks_when_stop_event_set_after_receive(
+    default_queue: SQSQueue,
+) -> None:
+    """Line 803: break when stop_event is set after _receive_messages returns."""
+    broker = SQSBroker(sqs_queue_name=default_queue.name)
+    broker._queue_urls[default_queue.name] = "queue-url"
+    stop_event = asyncio.Event()
+
+    async def _mock_receive(queue: object, url: object) -> list[object]:
+        stop_event.set()
+        return []
+
+    broker._receive_messages = _mock_receive  # type: ignore[method-assign]
+    send_stream = _FakeSendStream()
+
+    await broker._listen_single(default_queue, cast(Any, send_stream), stop_event)
+
+    assert send_stream.messages == []
+
+
+@pytest.mark.anyio
+async def test_listen_single_uses_empty_attributes_for_non_dict_message_attributes(
+    default_queue: SQSQueue,
+) -> None:
+    """Line 816: attributes = {} when MessageAttributes is not a dict."""
+    broker = SQSBroker(sqs_queue_name=default_queue.name)
+    broker._queue_urls[default_queue.name] = "queue-url"
+    broker._receive_messages = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            [
+                {
+                    "Body": "payload",
+                    "ReceiptHandle": "receipt",
+                    "MessageAttributes": "not-a-dict",  # triggers else branch
+                },
+            ],
+            asyncio.CancelledError(),
+        ],
+    )
+
+    send_stream = _FakeSendStream()
+
+    with pytest.raises(asyncio.CancelledError):
+        await broker._listen_single(
+            default_queue,
+            cast(Any, send_stream),
+            asyncio.Event(),
+        )
+
+    assert len(send_stream.messages) == 1
+
+
+class _FakeSendStream:
+    def __init__(self) -> None:
+        self.messages: list[AckableMessage] = []
+
+    async def __aenter__(self) -> "_FakeSendStream":
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> bool:
+        return False
+
+    async def send(self, message: AckableMessage) -> None:
+        self.messages.append(message)
+
+
+class _FakeS3Body:
+    async def __aenter__(self) -> "_FakeS3Body":
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> bool:
+        return False
+
+    async def read(self) -> bytes:
+        return b"from-s3"
+
+
+@pytest.mark.anyio
+async def test_listen_single_raises_when_queue_url_missing(
+    default_queue: SQSQueue,
+) -> None:
+    broker = SQSBroker(sqs_queue_name=default_queue.name)
+
+    with pytest.raises(BrokerConfigError):
+        await broker._listen_single(
+            default_queue,
+            cast(Any, _FakeSendStream()),
+            asyncio.Event(),
+        )
+
+
+@pytest.mark.anyio
+async def test_listen_single_skips_invalid_messages_and_sends_plain_message(
+    default_queue: SQSQueue,
+) -> None:
+    broker = SQSBroker(sqs_queue_name=default_queue.name)
+    broker._queue_urls[default_queue.name] = "queue-url"
+    broker._receive_messages = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            [
+                "not-a-dict",
+                {"Body": None, "ReceiptHandle": "missing-body"},
+                {"Body": "payload", "ReceiptHandle": "receipt-handle"},
+            ],
+            asyncio.CancelledError(),
+        ],
+    )
+
+    send_stream = _FakeSendStream()
+
+    with pytest.raises(asyncio.CancelledError):
+        await broker._listen_single(
+            default_queue,
+            cast(Any, send_stream),
+            asyncio.Event(),
+        )
+
+    assert len(send_stream.messages) == 1
+    assert send_stream.messages[0].data == b"payload"
+
+
+@pytest.mark.anyio
+async def test_listen_single_loads_s3_extended_message(default_queue: SQSQueue) -> None:
+    broker = SQSBroker(sqs_queue_name=default_queue.name)
+    broker._queue_urls[default_queue.name] = "queue-url"
+    broker._receive_messages = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            [
+                {
+                    "Body": '{"s3_bucket": "bucket", "s3_key": "key"}',
+                    "ReceiptHandle": "receipt-handle",
+                    "MessageAttributes": {
+                        "s3_extended_message": {"DataType": "String"}
+                    },
+                },
+            ],
+            asyncio.CancelledError(),
+        ],
+    )
+    cast(Any, broker)._s3_client = cast(
+        S3Client,
+        SimpleNamespace(get_object=AsyncMock(return_value={"Body": _FakeS3Body()})),
+    )
+
+    send_stream = _FakeSendStream()
+
+    with pytest.raises(asyncio.CancelledError):
+        await broker._listen_single(
+            default_queue,
+            cast(Any, send_stream),
+            asyncio.Event(),
+        )
+
+    assert len(send_stream.messages) == 1
+    assert send_stream.messages[0].data == b"from-s3"
+
+
+@pytest.mark.anyio
+async def test_receive_messages_includes_visibility_timeout() -> None:
+    queue = SQSQueue(
+        name="taskiq-default",
+        wait_time_seconds=0,
+        visibility_timeout=7,
+    )
+    broker = SQSBroker(sqs_queue_name=queue.name)
+    receive_message_mock = AsyncMock(return_value={})
+    cast(Any, broker)._sqs_client = SimpleNamespace(
+        receive_message=receive_message_mock
+    )
+
+    messages = await broker._receive_messages(queue, "queue-url")
+
+    assert messages == []
+    receive_message_mock.assert_awaited_once_with(
+        QueueUrl="queue-url",
+        MaxNumberOfMessages=1,
+        MessageAttributeNames=["All"],
+        WaitTimeSeconds=0,
+        VisibilityTimeout=7,
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -240,119 +240,12 @@ wheels = [
 ]
 
 [[package]]
-name = "build"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "os_name == 'nt'" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.10.2'" },
-    { name = "packaging" },
-    { name = "pyproject-hooks" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/1c/23e33405a7c9eac261dff640926b8b5adaed6a6eb3e1767d441ed611d0c0/build-1.3.0.tar.gz", hash = "sha256:698edd0ea270bde950f53aed21f3a0135672206f3911e0176261a31e0e07b397", size = 48544, upload-time = "2025-08-01T21:27:09.268Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/8c/2b30c12155ad8de0cf641d76a8b396a16d2c36bc6d50b621a62b7c4567c1/build-1.3.0-py3-none-any.whl", hash = "sha256:7145f0b5061ba90a1500d60bd1b13ca0a8a4cebdd0cc16ed8adf1c0e739f43b4", size = 23382, upload-time = "2025-08-01T21:27:07.844Z" },
-]
-
-[[package]]
-name = "cachetools"
-version = "6.2.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/44/5dc354b9f2df614673c2a542a630ef95d578b4a8673a1046d1137a7e2453/cachetools-6.2.3.tar.gz", hash = "sha256:64e0a4ddf275041dd01f5b873efa87c91ea49022b844b8c5d1ad3407c0f42f1f", size = 31641, upload-time = "2025-12-12T21:18:06.011Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/de/aa4cfc69feb5b3d604310214369979bb222ed0df0e2575a1b6e7af1a5579/cachetools-6.2.3-py3-none-any.whl", hash = "sha256:3fde34f7033979efb1e79b07ae529c2c40808bdd23b0b731405a48439254fba5", size = 11554, upload-time = "2025-12-12T21:18:04.556Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2025.11.12"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/8c/58f469717fa48465e4a50c014a0400602d3c437d7c0c468e17ada824da3a/certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316", size = 160538, upload-time = "2025-11-12T02:54:51.517Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b", size = 159438, upload-time = "2025-11-12T02:54:49.735Z" },
-]
-
-[[package]]
-name = "cffi"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44", size = 184283, upload-time = "2025-09-08T23:22:08.01Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/84/ad6a0b408daa859246f57c03efd28e5dd1b33c21737c2db84cae8c237aa5/cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49", size = 180504, upload-time = "2025-09-08T23:22:10.637Z" },
-    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811, upload-time = "2025-09-08T23:22:12.267Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402, upload-time = "2025-09-08T23:22:13.455Z" },
-    { url = "https://files.pythonhosted.org/packages/05/eb/b86f2a2645b62adcfff53b0dd97e8dfafb5c8aa864bd0d9a2c2049a0d551/cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0", size = 203217, upload-time = "2025-09-08T23:22:14.596Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/e0/6cbe77a53acf5acc7c08cc186c9928864bd7c005f9efd0d126884858a5fe/cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4", size = 203079, upload-time = "2025-09-08T23:22:15.769Z" },
-    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475, upload-time = "2025-09-08T23:22:17.427Z" },
-    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829, upload-time = "2025-09-08T23:22:19.069Z" },
-    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211, upload-time = "2025-09-08T23:22:20.588Z" },
-    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036, upload-time = "2025-09-08T23:22:22.143Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/cc/027d7fb82e58c48ea717149b03bcadcbdc293553edb283af792bd4bcbb3f/cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a", size = 172184, upload-time = "2025-09-08T23:22:23.328Z" },
-    { url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739", size = 182790, upload-time = "2025-09-08T23:22:24.752Z" },
-    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
-    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
-    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
-    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
-    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
-    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
-    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
-    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
-    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
-    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
-    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
-    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
-    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
-    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
-    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
-    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
-    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -579,66 +472,6 @@ toml = [
 ]
 
 [[package]]
-name = "cryptography"
-version = "46.0.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/60/04/ee2a9e8542e4fa2773b81771ff8349ff19cdd56b7258a0cc442639052edb/cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d", size = 750064, upload-time = "2026-02-10T19:18:38.255Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/81/b0bb27f2ba931a65409c6b8a8b358a7f03c0e46eceacddff55f7c84b1f3b/cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad", size = 7176289, upload-time = "2026-02-10T19:17:08.274Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/9e/6b4397a3e3d15123de3b1806ef342522393d50736c13b20ec4c9ea6693a6/cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b", size = 4275637, upload-time = "2026-02-10T19:17:10.53Z" },
-    { url = "https://files.pythonhosted.org/packages/63/e7/471ab61099a3920b0c77852ea3f0ea611c9702f651600397ac567848b897/cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b", size = 4424742, upload-time = "2026-02-10T19:17:12.388Z" },
-    { url = "https://files.pythonhosted.org/packages/37/53/a18500f270342d66bf7e4d9f091114e31e5ee9e7375a5aba2e85a91e0044/cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263", size = 4277528, upload-time = "2026-02-10T19:17:13.853Z" },
-    { url = "https://files.pythonhosted.org/packages/22/29/c2e812ebc38c57b40e7c583895e73c8c5adb4d1e4a0cc4c5a4fdab2b1acc/cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d", size = 4947993, upload-time = "2026-02-10T19:17:15.618Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/e7/237155ae19a9023de7e30ec64e5d99a9431a567407ac21170a046d22a5a3/cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed", size = 4456855, upload-time = "2026-02-10T19:17:17.221Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/87/fc628a7ad85b81206738abbd213b07702bcbdada1dd43f72236ef3cffbb5/cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2", size = 3984635, upload-time = "2026-02-10T19:17:18.792Z" },
-    { url = "https://files.pythonhosted.org/packages/84/29/65b55622bde135aedf4565dc509d99b560ee4095e56989e815f8fd2aa910/cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2", size = 4277038, upload-time = "2026-02-10T19:17:20.256Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/36/45e76c68d7311432741faf1fbf7fac8a196a0a735ca21f504c75d37e2558/cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0", size = 4912181, upload-time = "2026-02-10T19:17:21.825Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/1a/c1ba8fead184d6e3d5afcf03d569acac5ad063f3ac9fb7258af158f7e378/cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731", size = 4456482, upload-time = "2026-02-10T19:17:25.133Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/e5/3fb22e37f66827ced3b902cf895e6a6bc1d095b5b26be26bd13c441fdf19/cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82", size = 4405497, upload-time = "2026-02-10T19:17:26.66Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/df/9d58bb32b1121a8a2f27383fabae4d63080c7ca60b9b5c88be742be04ee7/cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1", size = 4667819, upload-time = "2026-02-10T19:17:28.569Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/ed/325d2a490c5e94038cdb0117da9397ece1f11201f425c4e9c57fe5b9f08b/cryptography-46.0.5-cp311-abi3-win32.whl", hash = "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48", size = 3028230, upload-time = "2026-02-10T19:17:30.518Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/5a/ac0f49e48063ab4255d9e3b79f5def51697fce1a95ea1370f03dc9db76f6/cryptography-46.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4", size = 3480909, upload-time = "2026-02-10T19:17:32.083Z" },
-    { url = "https://files.pythonhosted.org/packages/00/13/3d278bfa7a15a96b9dc22db5a12ad1e48a9eb3d40e1827ef66a5df75d0d0/cryptography-46.0.5-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:94a76daa32eb78d61339aff7952ea819b1734b46f73646a07decb40e5b3448e2", size = 7119287, upload-time = "2026-02-10T19:17:33.801Z" },
-    { url = "https://files.pythonhosted.org/packages/67/c8/581a6702e14f0898a0848105cbefd20c058099e2c2d22ef4e476dfec75d7/cryptography-46.0.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5be7bf2fb40769e05739dd0046e7b26f9d4670badc7b032d6ce4db64dddc0678", size = 4265728, upload-time = "2026-02-10T19:17:35.569Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/4a/ba1a65ce8fc65435e5a849558379896c957870dd64fecea97b1ad5f46a37/cryptography-46.0.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe346b143ff9685e40192a4960938545c699054ba11d4f9029f94751e3f71d87", size = 4408287, upload-time = "2026-02-10T19:17:36.938Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/67/8ffdbf7b65ed1ac224d1c2df3943553766914a8ca718747ee3871da6107e/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c69fd885df7d089548a42d5ec05be26050ebcd2283d89b3d30676eb32ff87dee", size = 4270291, upload-time = "2026-02-10T19:17:38.748Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/e5/f52377ee93bc2f2bba55a41a886fd208c15276ffbd2569f2ddc89d50e2c5/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:8293f3dea7fc929ef7240796ba231413afa7b68ce38fd21da2995549f5961981", size = 4927539, upload-time = "2026-02-10T19:17:40.241Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/02/cfe39181b02419bbbbcf3abdd16c1c5c8541f03ca8bda240debc467d5a12/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9", size = 4442199, upload-time = "2026-02-10T19:17:41.789Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/96/2fcaeb4873e536cf71421a388a6c11b5bc846e986b2b069c79363dc1648e/cryptography-46.0.5-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:d66e421495fdb797610a08f43b05269e0a5ea7f5e652a89bfd5a7d3c1dee3648", size = 3960131, upload-time = "2026-02-10T19:17:43.379Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/d2/b27631f401ddd644e94c5cf33c9a4069f72011821cf3dc7309546b0642a0/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:4e817a8920bfbcff8940ecfd60f23d01836408242b30f1a708d93198393a80b4", size = 4270072, upload-time = "2026-02-10T19:17:45.481Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/a7/60d32b0370dae0b4ebe55ffa10e8599a2a59935b5ece1b9f06edb73abdeb/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:68f68d13f2e1cb95163fa3b4db4bf9a159a418f5f6e7242564fc75fcae667fd0", size = 4892170, upload-time = "2026-02-10T19:17:46.997Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/b9/cf73ddf8ef1164330eb0b199a589103c363afa0cf794218c24d524a58eab/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a3d1fae9863299076f05cb8a778c467578262fae09f9dc0ee9b12eb4268ce663", size = 4441741, upload-time = "2026-02-10T19:17:48.661Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/eb/eee00b28c84c726fe8fa0158c65afe312d9c3b78d9d01daf700f1f6e37ff/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4143987a42a2397f2fc3b4d7e3a7d313fbe684f67ff443999e803dd75a76826", size = 4396728, upload-time = "2026-02-10T19:17:50.058Z" },
-    { url = "https://files.pythonhosted.org/packages/65/f4/6bc1a9ed5aef7145045114b75b77c2a8261b4d38717bd8dea111a63c3442/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7d731d4b107030987fd61a7f8ab512b25b53cef8f233a97379ede116f30eb67d", size = 4652001, upload-time = "2026-02-10T19:17:51.54Z" },
-    { url = "https://files.pythonhosted.org/packages/86/ef/5d00ef966ddd71ac2e6951d278884a84a40ffbd88948ef0e294b214ae9e4/cryptography-46.0.5-cp314-cp314t-win32.whl", hash = "sha256:c3bcce8521d785d510b2aad26ae2c966092b7daa8f45dd8f44734a104dc0bc1a", size = 3003637, upload-time = "2026-02-10T19:17:52.997Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/57/f3f4160123da6d098db78350fdfd9705057aad21de7388eacb2401dceab9/cryptography-46.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:4d8ae8659ab18c65ced284993c2265910f6c9e650189d4e3f68445ef82a810e4", size = 3469487, upload-time = "2026-02-10T19:17:54.549Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/fa/a66aa722105ad6a458bebd64086ca2b72cdd361fed31763d20390f6f1389/cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31", size = 7170514, upload-time = "2026-02-10T19:17:56.267Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/04/c85bdeab78c8bc77b701bf0d9bdcf514c044e18a46dcff330df5448631b0/cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18", size = 4275349, upload-time = "2026-02-10T19:17:58.419Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/32/9b87132a2f91ee7f5223b091dc963055503e9b442c98fc0b8a5ca765fab0/cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235", size = 4420667, upload-time = "2026-02-10T19:18:00.619Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/a6/a7cb7010bec4b7c5692ca6f024150371b295ee1c108bdc1c400e4c44562b/cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a", size = 4276980, upload-time = "2026-02-10T19:18:02.379Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/7c/c4f45e0eeff9b91e3f12dbd0e165fcf2a38847288fcfd889deea99fb7b6d/cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76", size = 4939143, upload-time = "2026-02-10T19:18:03.964Z" },
-    { url = "https://files.pythonhosted.org/packages/37/19/e1b8f964a834eddb44fa1b9a9976f4e414cbb7aa62809b6760c8803d22d1/cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614", size = 4453674, upload-time = "2026-02-10T19:18:05.588Z" },
-    { url = "https://files.pythonhosted.org/packages/db/ed/db15d3956f65264ca204625597c410d420e26530c4e2943e05a0d2f24d51/cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229", size = 3978801, upload-time = "2026-02-10T19:18:07.167Z" },
-    { url = "https://files.pythonhosted.org/packages/41/e2/df40a31d82df0a70a0daf69791f91dbb70e47644c58581d654879b382d11/cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1", size = 4276755, upload-time = "2026-02-10T19:18:09.813Z" },
-    { url = "https://files.pythonhosted.org/packages/33/45/726809d1176959f4a896b86907b98ff4391a8aa29c0aaaf9450a8a10630e/cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d", size = 4901539, upload-time = "2026-02-10T19:18:11.263Z" },
-    { url = "https://files.pythonhosted.org/packages/99/0f/a3076874e9c88ecb2ecc31382f6e7c21b428ede6f55aafa1aa272613e3cd/cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c", size = 4452794, upload-time = "2026-02-10T19:18:12.914Z" },
-    { url = "https://files.pythonhosted.org/packages/02/ef/ffeb542d3683d24194a38f66ca17c0a4b8bf10631feef44a7ef64e631b1a/cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4", size = 4404160, upload-time = "2026-02-10T19:18:14.375Z" },
-    { url = "https://files.pythonhosted.org/packages/96/93/682d2b43c1d5f1406ed048f377c0fc9fc8f7b0447a478d5c65ab3d3a66eb/cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9", size = 4667123, upload-time = "2026-02-10T19:18:15.886Z" },
-    { url = "https://files.pythonhosted.org/packages/45/2d/9c5f2926cb5300a8eefc3f4f0b3f3df39db7f7ce40c8365444c49363cbda/cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72", size = 3010220, upload-time = "2026-02-10T19:18:17.361Z" },
-    { url = "https://files.pythonhosted.org/packages/48/ef/0c2f4a8e31018a986949d34a01115dd057bf536905dca38897bacd21fac3/cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595", size = 3467050, upload-time = "2026-02-10T19:18:18.899Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/dd/2d9fdb07cebdf3d51179730afb7d5e576153c6744c3ff8fded23030c204e/cryptography-46.0.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:3b4995dc971c9fb83c25aa44cf45f02ba86f71ee600d81091c2f0cbae116b06c", size = 3476964, upload-time = "2026-02-10T19:18:20.687Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/6f/6cc6cc9955caa6eaf83660b0da2b077c7fe8ff9950a3c5e45d605038d439/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:bc84e875994c3b445871ea7181d424588171efec3e185dced958dad9e001950a", size = 4218321, upload-time = "2026-02-10T19:18:22.349Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/5d/c4da701939eeee699566a6c1367427ab91a8b7088cc2328c09dbee940415/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:2ae6971afd6246710480e3f15824ed3029a60fc16991db250034efd0b9fb4356", size = 4381786, upload-time = "2026-02-10T19:18:24.529Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/97/a538654732974a94ff96c1db621fa464f455c02d4bb7d2652f4edc21d600/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d861ee9e76ace6cf36a6a89b959ec08e7bc2493ee39d07ffe5acb23ef46d27da", size = 4217990, upload-time = "2026-02-10T19:18:25.957Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/11/7e500d2dd3ba891197b9efd2da5454b74336d64a7cc419aa7327ab74e5f6/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:2b7a67c9cd56372f3249b39699f2ad479f6991e62ea15800973b956f4b73e257", size = 4381252, upload-time = "2026-02-10T19:18:27.496Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/58/6b3d24e6b9bc474a2dcdee65dfd1f008867015408a271562e4b690561a4d/cryptography-46.0.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8456928655f856c6e1533ff59d5be76578a7157224dbd9ce6872f25055ab9ab7", size = 3407605, upload-time = "2026-02-10T19:18:29.233Z" },
-]
-
-[[package]]
 name = "defusedxml"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -648,51 +481,12 @@ wheels = [
 ]
 
 [[package]]
-name = "dill"
-version = "0.3.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7c/e7/364a09134e1062d4d5ff69b853a56cf61c223e0afcc6906b6832bcd51ea8/dill-0.3.6.tar.gz", hash = "sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373", size = 179026, upload-time = "2022-10-23T22:46:33.146Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/e3/a84bf2e561beed15813080d693b4b27573262433fced9c1d1fea59e60553/dill-0.3.6-py3-none-any.whl", hash = "sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0", size = 110515, upload-time = "2022-10-23T22:46:30.986Z" },
-]
-
-[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
-]
-
-[[package]]
-name = "dnslib"
-version = "0.9.26"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/71/269f74ef9bc8ca453af2e1768d4f4c8e7ef5f894d058d27fd1b69c754d7f/dnslib-0.9.26.tar.gz", hash = "sha256:be56857534390b2fbd02935270019bacc5e6b411d156cb3921ac55a7fb51f1a8", size = 82901, upload-time = "2025-03-03T09:17:32.606Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/93/167364f10194e374119b211e475ed8763d7591ae4f7001b304282dde5825/dnslib-0.9.26-py3-none-any.whl", hash = "sha256:e68719e633d761747c7e91bd241019ef5a2b61a63f56025939e144c841a70e0d", size = 64161, upload-time = "2025-03-03T09:17:31.47Z" },
-]
-
-[[package]]
-name = "dnspython"
-version = "2.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.19.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/1f/924e3caae75f471eae4b26bd13b698f6af2c44279f67af317439c2f4c46a/ecdsa-0.19.1.tar.gz", hash = "sha256:478cba7b62555866fcb3bb3fe985e06decbdb68ef55713c4e5ab98c57d508e61", size = 201793, upload-time = "2025-03-13T11:52:43.25Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/a3/460c57f094a4a165c84a1341c373b0a4f5ec6ac244b998d5021aade89b77/ecdsa-0.19.1-py2.py3-none-any.whl", hash = "sha256:30638e27cf77b7e15c4c4cc1973720149e1033827cfd00661ca5c8cc0cdb24c3", size = 150607, upload-time = "2025-03-13T11:52:41.757Z" },
 ]
 
 [[package]]
@@ -858,6 +652,65 @@ coverage = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
+]
+
+[[package]]
+name = "hypercorn"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "h11" },
+    { name = "h2" },
+    { name = "priority" },
+    { name = "taskgroup", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/01/39f41a014b83dd5c795217362f2ca9071cf243e6a75bdcd6cd5b944658cc/hypercorn-0.18.0.tar.gz", hash = "sha256:d63267548939c46b0247dc8e5b45a9947590e35e64ee73a23c074aa3cf88e9da", size = 68420, upload-time = "2025-11-08T13:54:04.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/35/850277d1b17b206bd10874c8a9a3f52e059452fb49bb0d22cbb908f6038b/hypercorn-0.18.0-py3-none-any.whl", hash = "sha256:225e268f2c1c2f28f6d8f6db8f40cb8c992963610c5725e13ccfcddccb24b1cd", size = 61640, upload-time = "2025-11-08T13:54:03.202Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.15"
 source = { registry = "https://pypi.org/simple" }
@@ -873,18 +726,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
-]
-
-[[package]]
-name = "importlib-metadata"
-version = "8.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
 ]
 
 [[package]]
@@ -915,82 +756,17 @@ wheels = [
 ]
 
 [[package]]
-name = "localstack"
-version = "3.7.2"
+name = "ministack"
+version = "1.3.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "localstack-core" },
-    { name = "localstack-ext" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/80/42/0cc00bc5896a063cdbac6bba6850d5425a8c2fab422b05a6b1a39156206b/localstack-3.7.2.tar.gz", hash = "sha256:663c70a4e5a234ded4878a011985c42037e59fc763224b14de19964c49b3a1c1", size = 5741, upload-time = "2024-09-06T12:00:17.257Z" }
-
-[[package]]
-name = "localstack-core"
-version = "3.7.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "build" },
-    { name = "cachetools" },
-    { name = "click" },
-    { name = "cryptography" },
-    { name = "dill" },
-    { name = "dnslib" },
-    { name = "dnspython" },
-    { name = "plux" },
-    { name = "psutil" },
-    { name = "python-dotenv" },
+    { name = "defusedxml" },
+    { name = "hypercorn" },
     { name = "pyyaml" },
-    { name = "requests" },
-    { name = "rich" },
-    { name = "semver" },
-    { name = "tailer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/f0/95afedcf10c71544b7ab45475150463d8a4f03992bd15b8429e7908888e3/localstack_core-3.7.2.tar.gz", hash = "sha256:e0f334642f4ffbee53e0a997a11a14016a3da5d75b152784dd5fa795570b897d", size = 9805206, upload-time = "2024-09-06T11:53:54.072Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/ad/19649beb3d4d6260b488353b9753d2127c88aabd7fc1ade5556cbfa118c5/ministack-1.3.16.tar.gz", hash = "sha256:bcae2d8f93a5414a369878a2e7b27e465204d888228e913a21fc86b8e8ad334c", size = 875800, upload-time = "2026-04-27T21:58:11.232Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/bf/4a0e3093431faff2b713b44e5643b131f0f8da8351618b02024c4c919df3/localstack_core-3.7.2-py3-none-any.whl", hash = "sha256:ac11ed95af6397575ea40dc535fe3ed1fb1dc718dfd45ca73de4e137bc8c2a5f", size = 2341306, upload-time = "2024-09-06T11:53:50.52Z" },
-]
-
-[[package]]
-name = "localstack-ext"
-version = "3.7.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "build" },
-    { name = "dill" },
-    { name = "dnslib" },
-    { name = "dnspython" },
-    { name = "localstack-core" },
-    { name = "packaging" },
-    { name = "plux" },
-    { name = "pyaes" },
-    { name = "pyotp" },
-    { name = "python-dateutil" },
-    { name = "python-jose", extra = ["cryptography"] },
-    { name = "requests" },
-    { name = "tabulate" },
-    { name = "windows-curses", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/f6/f25fc32a20f7a105b6009de44e4528dda5dcdbd8c8f3d3c8cb09aa1e920d/localstack_ext-3.7.2.tar.gz", hash = "sha256:81df87c999dece0b4aad2289398b715191d33ccaeba4a5901c6bda22cf45c95b", size = 7148500, upload-time = "2024-09-06T12:00:20.19Z" }
-
-[[package]]
-name = "markdown-it-py"
-version = "4.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mdurl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
-]
-
-[[package]]
-name = "mdurl"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/c6/5bd9681fb40c6df73fe42fd1688a7310ce3500be069fd21d4fbfbf59f6f1/ministack-1.3.16-py3-none-any.whl", hash = "sha256:f04d35ec354e7061192d8970f89f80f09b387ebb4d6193a16f2c7903aebc0ec4", size = 586124, upload-time = "2026-04-27T21:58:09.163Z" },
 ]
 
 [[package]]
@@ -1347,15 +1123,6 @@ wheels = [
 ]
 
 [[package]]
-name = "plux"
-version = "1.13.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/14/4b/bea3ff709d4d17b1e0351058c9dbe830dcbb33a75225836056f4591dfb1d/plux-1.13.0.tar.gz", hash = "sha256:0358a618883be270cf8dd6b5ae48e633a7fecd386cff6347c8560116f4688a75", size = 32977, upload-time = "2025-08-04T21:48:46.623Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/56/6a03c5a7c88d05cc4ed3a07fede3185b42b13cf74025b691d1377dd22647/plux-1.13.0-py3-none-any.whl", hash = "sha256:0b68cb35fc3bf4b2a760ef6892ea734a1c0d241e2f403540005fa26436773a62", size = 35300, upload-time = "2025-08-04T21:48:45.038Z" },
-]
-
-[[package]]
 name = "pre-commit"
 version = "4.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1369,6 +1136,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f4/9b/6a4ffb4ed980519da959e1cf3122fc6cb41211daa58dbae1c73c0e519a37/pre_commit-4.5.0.tar.gz", hash = "sha256:dc5a065e932b19fc1d4c653c6939068fe54325af8e741e74e88db4d28a4dd66b", size = 198428, upload-time = "2025-11-22T21:02:42.304Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/c4/b2d28e9d2edf4f1713eb3c29307f1a63f3d67cf09bdda29715a36a68921a/pre_commit-4.5.0-py2.py3-none-any.whl", hash = "sha256:25e2ce09595174d9c97860a95609f9f852c0614ba602de3561e267547f2335e1", size = 226429, upload-time = "2025-11-22T21:02:40.836Z" },
+]
+
+[[package]]
+name = "priority"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/3c/eb7c35f4dcede96fca1842dac5f4f5d15511aa4b52f3a961219e68ae9204/priority-2.0.0.tar.gz", hash = "sha256:c965d54f1b8d0d0b19479db3924c7c36cf672dbf2aec92d43fbdaf4492ba18c0", size = 24792, upload-time = "2021-06-27T10:15:05.487Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/5f/82c8074f7e84978129347c2c6ec8b6c59f3584ff1a20bc3c940a3e061790/priority-2.0.0-py3-none-any.whl", hash = "sha256:6f8eefce5f3ad59baf2c080a664037bb4725cd0a790d53d59ab4059288faf6aa", size = 8946, upload-time = "2021-06-27T10:15:03.856Z" },
 ]
 
 [[package]]
@@ -1483,56 +1259,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
     { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
-]
-
-[[package]]
-name = "psutil"
-version = "7.1.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e1/88/bdd0a41e5857d5d703287598cbf08dad90aed56774ea52ae071bae9071b6/psutil-7.1.3.tar.gz", hash = "sha256:6c86281738d77335af7aec228328e944b30930899ea760ecf33a4dba66be5e74", size = 489059, upload-time = "2025-11-02T12:25:54.619Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/93/0c49e776b8734fef56ec9c5c57f923922f2cf0497d62e0f419465f28f3d0/psutil-7.1.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0005da714eee687b4b8decd3d6cc7c6db36215c9e74e5ad2264b90c3df7d92dc", size = 239751, upload-time = "2025-11-02T12:25:58.161Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/8d/b31e39c769e70780f007969815195a55c81a63efebdd4dbe9e7a113adb2f/psutil-7.1.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:19644c85dcb987e35eeeaefdc3915d059dac7bd1167cdcdbf27e0ce2df0c08c0", size = 240368, upload-time = "2025-11-02T12:26:00.491Z" },
-    { url = "https://files.pythonhosted.org/packages/62/61/23fd4acc3c9eebbf6b6c78bcd89e5d020cfde4acf0a9233e9d4e3fa698b4/psutil-7.1.3-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95ef04cf2e5ba0ab9eaafc4a11eaae91b44f4ef5541acd2ee91d9108d00d59a7", size = 287134, upload-time = "2025-11-02T12:26:02.613Z" },
-    { url = "https://files.pythonhosted.org/packages/30/1c/f921a009ea9ceb51aa355cb0cc118f68d354db36eae18174bab63affb3e6/psutil-7.1.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1068c303be3a72f8e18e412c5b2a8f6d31750fb152f9cb106b54090296c9d251", size = 289904, upload-time = "2025-11-02T12:26:05.207Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/82/62d68066e13e46a5116df187d319d1724b3f437ddd0f958756fc052677f4/psutil-7.1.3-cp313-cp313t-win_amd64.whl", hash = "sha256:18349c5c24b06ac5612c0428ec2a0331c26443d259e2a0144a9b24b4395b58fa", size = 249642, upload-time = "2025-11-02T12:26:07.447Z" },
-    { url = "https://files.pythonhosted.org/packages/df/ad/c1cd5fe965c14a0392112f68362cfceb5230819dbb5b1888950d18a11d9f/psutil-7.1.3-cp313-cp313t-win_arm64.whl", hash = "sha256:c525ffa774fe4496282fb0b1187725793de3e7c6b29e41562733cae9ada151ee", size = 245518, upload-time = "2025-11-02T12:26:09.719Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/bb/6670bded3e3236eb4287c7bcdc167e9fae6e1e9286e437f7111caed2f909/psutil-7.1.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b403da1df4d6d43973dc004d19cee3b848e998ae3154cc8097d139b77156c353", size = 239843, upload-time = "2025-11-02T12:26:11.968Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/66/853d50e75a38c9a7370ddbeefabdd3d3116b9c31ef94dc92c6729bc36bec/psutil-7.1.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ad81425efc5e75da3f39b3e636293360ad8d0b49bed7df824c79764fb4ba9b8b", size = 240369, upload-time = "2025-11-02T12:26:14.358Z" },
-    { url = "https://files.pythonhosted.org/packages/41/bd/313aba97cb5bfb26916dc29cf0646cbe4dd6a89ca69e8c6edce654876d39/psutil-7.1.3-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f33a3702e167783a9213db10ad29650ebf383946e91bc77f28a5eb083496bc9", size = 288210, upload-time = "2025-11-02T12:26:16.699Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/fa/76e3c06e760927a0cfb5705eb38164254de34e9bd86db656d4dbaa228b04/psutil-7.1.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fac9cd332c67f4422504297889da5ab7e05fd11e3c4392140f7370f4208ded1f", size = 291182, upload-time = "2025-11-02T12:26:18.848Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/1d/5774a91607035ee5078b8fd747686ebec28a962f178712de100d00b78a32/psutil-7.1.3-cp314-cp314t-win_amd64.whl", hash = "sha256:3792983e23b69843aea49c8f5b8f115572c5ab64c153bada5270086a2123c7e7", size = 250466, upload-time = "2025-11-02T12:26:21.183Z" },
-    { url = "https://files.pythonhosted.org/packages/00/ca/e426584bacb43a5cb1ac91fae1937f478cd8fbe5e4ff96574e698a2c77cd/psutil-7.1.3-cp314-cp314t-win_arm64.whl", hash = "sha256:31d77fcedb7529f27bb3a0472bea9334349f9a04160e8e6e5020f22c59893264", size = 245756, upload-time = "2025-11-02T12:26:23.148Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/94/46b9154a800253e7ecff5aaacdf8ebf43db99de4a2dfa18575b02548654e/psutil-7.1.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2bdbcd0e58ca14996a42adf3621a6244f1bb2e2e528886959c72cf1e326677ab", size = 238359, upload-time = "2025-11-02T12:26:25.284Z" },
-    { url = "https://files.pythonhosted.org/packages/68/3a/9f93cff5c025029a36d9a92fef47220ab4692ee7f2be0fba9f92813d0cb8/psutil-7.1.3-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:bc31fa00f1fbc3c3802141eede66f3a2d51d89716a194bf2cd6fc68310a19880", size = 239171, upload-time = "2025-11-02T12:26:27.23Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/b1/5f49af514f76431ba4eea935b8ad3725cdeb397e9245ab919dbc1d1dc20f/psutil-7.1.3-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3bb428f9f05c1225a558f53e30ccbad9930b11c3fc206836242de1091d3e7dd3", size = 263261, upload-time = "2025-11-02T12:26:29.48Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/95/992c8816a74016eb095e73585d747e0a8ea21a061ed3689474fabb29a395/psutil-7.1.3-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:56d974e02ca2c8eb4812c3f76c30e28836fffc311d55d979f1465c1feeb2b68b", size = 264635, upload-time = "2025-11-02T12:26:31.74Z" },
-    { url = "https://files.pythonhosted.org/packages/55/4c/c3ed1a622b6ae2fd3c945a366e64eb35247a31e4db16cf5095e269e8eb3c/psutil-7.1.3-cp37-abi3-win_amd64.whl", hash = "sha256:f39c2c19fe824b47484b96f9692932248a54c43799a84282cfe58d05a6449efd", size = 247633, upload-time = "2025-11-02T12:26:33.887Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/ad/33b2ccec09bf96c2b2ef3f9a6f66baac8253d7565d8839e024a6b905d45d/psutil-7.1.3-cp37-abi3-win_arm64.whl", hash = "sha256:bd0d69cee829226a761e92f28140bec9a5ee9d5b4fb4b0cc589068dbfff559b1", size = 244608, upload-time = "2025-11-02T12:26:36.136Z" },
-]
-
-[[package]]
-name = "pyaes"
-version = "1.6.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/44/66/2c17bae31c906613795711fc78045c285048168919ace2220daa372c7d72/pyaes-1.6.1.tar.gz", hash = "sha256:02c1b1405c38d3c370b085fb952dd8bea3fadcee6411ad99f312cc129c536d8f", size = 28536, upload-time = "2017-09-20T21:17:54.23Z" }
-
-[[package]]
-name = "pyasn1"
-version = "0.6.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b", size = 146586, upload-time = "2026-01-16T18:04:18.534Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/b5/a96872e5184f354da9c84ae119971a0a4c221fe9b27a4d94bd43f2596727/pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf", size = 83371, upload-time = "2026-01-16T18:04:17.174Z" },
-]
-
-[[package]]
-name = "pycparser"
-version = "2.23"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
 ]
 
 [[package]]
@@ -1678,33 +1404,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pygments"
-version = "2.19.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
-]
-
-[[package]]
-name = "pyotp"
-version = "2.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/b2/1d5994ba2acde054a443bd5e2d384175449c7d2b6d1a0614dbca3a63abfc/pyotp-2.9.0.tar.gz", hash = "sha256:346b6642e0dbdde3b4ff5a930b664ca82abfa116356ed48cc42c7d6590d36f63", size = 17763, upload-time = "2023-07-27T23:41:03.295Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/c0/c33c8792c3e50193ef55adb95c1c3c2786fe281123291c2dbf0eaab95a6f/pyotp-2.9.0-py3-none-any.whl", hash = "sha256:81c2e5865b8ac55e825b0358e496e1d9387c811e85bb40e71a3b29b288963612", size = 13376, upload-time = "2023-07-27T23:41:01.685Z" },
-]
-
-[[package]]
-name = "pyproject-hooks"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
-]
-
-[[package]]
 name = "pyright"
 version = "1.1.407"
 source = { registry = "https://pypi.org/simple" }
@@ -1769,34 +1468,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
-name = "python-dotenv"
-version = "1.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
-]
-
-[[package]]
-name = "python-jose"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ecdsa" },
-    { name = "pyasn1" },
-    { name = "rsa" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
-]
-
-[package.optional-dependencies]
-cryptography = [
-    { name = "cryptography" },
 ]
 
 [[package]]
@@ -1879,31 +1550,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rich"
-version = "14.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
-]
-
-[[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.14.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1930,15 +1576,6 @@ wheels = [
 ]
 
 [[package]]
-name = "semver"
-version = "3.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/d1/d3159231aec234a59dd7d601e9dd9fe96f3afff15efd33c1070019b26132/semver-3.0.4.tar.gz", hash = "sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602", size = 269730, upload-time = "2025-01-24T13:19:27.617Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl", hash = "sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746", size = 17912, upload-time = "2025-01-24T13:19:24.949Z" },
-]
-
-[[package]]
 name = "setuptools"
 version = "80.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1957,19 +1594,17 @@ wheels = [
 ]
 
 [[package]]
-name = "tabulate"
-version = "0.9.0"
+name = "taskgroup"
+version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
+dependencies = [
+    { name = "exceptiongroup" },
+    { name = "typing-extensions" },
 ]
-
-[[package]]
-name = "tailer"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dd/05/01de24d6393d6da0c27857c76b0f9ae97b42cd6102bbdf76cce95e031295/tailer-0.4.1.tar.gz", hash = "sha256:78d60f23a1b8a2d32f400b3c8c06b01142ac7841b75d8a1efcb33515877ba531", size = 7504, upload-time = "2015-12-09T19:44:11.428Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/8d/e218e0160cc1b692e6e0e5ba34e8865dbb171efeb5fc9a704544b3020605/taskgroup-0.2.2.tar.gz", hash = "sha256:078483ac3e78f2e3f973e2edbf6941374fbea81b9c5d0a96f51d297717f4752d", size = 11504, upload-time = "2025-01-03T09:24:13.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/b1/74babcc824a57904e919f3af16d86c08b524c0691504baf038ef2d7f655c/taskgroup-0.2.2-py2.py3-none-any.whl", hash = "sha256:e2c53121609f4ae97303e9ea1524304b4de6faf9eb2c9280c7f87976479a52fb", size = 14237, upload-time = "2025-01-03T09:24:11.41Z" },
+]
 
 [[package]]
 name = "taskiq"
@@ -2010,7 +1645,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "genbadge", extra = ["coverage"] },
-    { name = "localstack" },
+    { name = "ministack" },
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest" },
@@ -2032,7 +1667,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "genbadge", extras = ["coverage"] },
-    { name = "localstack", specifier = "~=3.7.2" },
+    { name = "ministack", specifier = "~=1.3" },
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest", specifier = "~=8.3.3" },
@@ -2263,21 +1898,6 @@ wheels = [
 ]
 
 [[package]]
-name = "windows-curses"
-version = "2.4.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/34/e70815e7ae6f157c00121180a607dbcdc82acfd949c70bba28c45d206dec/windows_curses-2.4.1-cp310-cp310-win32.whl", hash = "sha256:53d711e07194d0d3ff7ceff29e0955b35479bc01465d46c3041de67b8141db2f", size = 71136, upload-time = "2025-01-11T00:26:15.273Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/1d/1bb512c445af24fb0a3dccf9537c8727bba5920e69539227b87f5351f608/windows_curses-2.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:325439cd4f37897a1de8a9c068a5b4c432f9244bf9c855ee2fbeb3fa721a770c", size = 81418, upload-time = "2025-01-11T00:26:16.963Z" },
-    { url = "https://files.pythonhosted.org/packages/74/b3/46a2508fff83b5affb5a311797c584c494b4b0c4c8796a1afa2c1b1e03ac/windows_curses-2.4.1-cp311-cp311-win32.whl", hash = "sha256:4fa1a176bfcf098d0c9bb7bc03dce6e83a4257fc0c66ad721f5745ebf0c00746", size = 71129, upload-time = "2025-01-11T00:26:19.137Z" },
-    { url = "https://files.pythonhosted.org/packages/50/29/fd7c0c80177d8df55f841504a5f332b95b0002c80f82055913b6caac94e6/windows_curses-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:fd7d7a9cf6c1758f46ed76b8c67f608bc5fcd5f0ca91f1580fd2d84cf41c7f4f", size = 81431, upload-time = "2025-01-11T00:26:20.359Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/99/60f34e51514c82631aa5c6d21eab88ce1701562de9844608411e39462a46/windows_curses-2.4.1-cp312-cp312-win32.whl", hash = "sha256:bdbe7d58747408aef8a9128b2654acf6fbd11c821b91224b9a046faba8c6b6ca", size = 71489, upload-time = "2025-01-11T00:26:22.726Z" },
-    { url = "https://files.pythonhosted.org/packages/62/8f/d908bcab1954375b156a9300fa86ceccb110f39457cd6fd59c72777626ab/windows_curses-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c9c2635faf171a229caca80e1dd760ab00db078e2a285ba2f667bbfcc31777c", size = 81777, upload-time = "2025-01-11T00:26:25.273Z" },
-    { url = "https://files.pythonhosted.org/packages/25/a0/e8d074f013117633f6b502ca123ecfc377fe0bd36818fe65e8935c91ca9c/windows_curses-2.4.1-cp313-cp313-win32.whl", hash = "sha256:05d1ca01e5199a435ccb6c8c2978df4a169cdff1ec99ab15f11ded9de8e5be26", size = 71390, upload-time = "2025-01-11T00:26:27.66Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/4b/2838a829b074a68c570d54ae0ae8539979657d3e619a4dc5a4b03eb69745/windows_curses-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8cf653f8928af19c103ae11cfed38124f418dcdd92643c4cd17239c0cec2f9da", size = 81636, upload-time = "2025-01-11T00:26:29.595Z" },
-]
-
-[[package]]
 name = "wrapt"
 version = "1.17.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2344,6 +1964,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
     { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
     { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
+]
+
+[[package]]
+name = "wsproto"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
 ]
 
 [[package]]
@@ -2470,13 +2102,4 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/86/0f0dccb6e59a9e7f122c5afd43568b1d31b8ab7dda5f1b01fb5c7025c9a9/yarl-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9fb17ea16e972c63d25d4a97f016d235c78dd2344820eb35bc034bc32012ee27", size = 96292, upload-time = "2025-10-06T14:12:15.398Z" },
     { url = "https://files.pythonhosted.org/packages/48/b7/503c98092fb3b344a179579f55814b613c1fbb1c23b3ec14a7b008a66a6e/yarl-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9f6d73c1436b934e3f01df1e1b21ff765cd1d28c77dfb9ace207f746d4610ee1", size = 85171, upload-time = "2025-10-06T14:12:16.935Z" },
     { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
-]
-
-[[package]]
-name = "zipp"
-version = "3.23.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [[package]]
@@ -2002,6 +2002,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiobotocore" },
     { name = "annotated-types" },
+    { name = "anyio" },
     { name = "pydantic" },
     { name = "taskiq", extra = ["orjson"] },
 ]
@@ -2023,7 +2024,8 @@ dev = [
 requires-dist = [
     { name = "aiobotocore", specifier = ">=2.23.1" },
     { name = "annotated-types", specifier = "~=0.7.0" },
-    { name = "pydantic", specifier = ">=1.0,<=3.0" },
+    { name = "anyio", specifier = ">=4.0" },
+    { name = "pydantic", specifier = ">=2.0,<3.0" },
     { name = "taskiq", extras = ["orjson"], specifier = ">=0.11.12,<1" },
 ]
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Introduces multi-queue support for the SQS broker so a single broker instance can publish to and consume from multiple queues, while preserving existing single-queue behavior.

Key changes included:

- Added queue registration and routing logic for default, named, and FIFO queues.
- Implemented per-queue batching behavior and queue-aware batch sending.
- Updated listen flow to fan in messages from all configured queues with safer lifecycle/shutdown handling.
- Expanded tests to cover multi-queue routing, batching, listening, edge cases...
- Tightened dependencies by explicitly requiring Pydantic v2. Fixes #41 


## Context and Motivation
<!--- Describe your reasoning for this change in detail -->
Motivated mainly by this [discussion](https://github.com/orgs/taskiq-python/discussions/448)
It also tackles #43 